### PR TITLE
Simplecov must be started before the application is loaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,8 @@ before_script:
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
+env:
+  global:
+    - CC_TEST_REPORTER_ID=859fcfe88b00c026d15dce30e838e2299face8088b49fe62bc3a02d1507ce3d5
 notifications:
   email: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'sdr_client'
 require 'byebug'
 require 'webmock/rspec'
-
 require 'simplecov'
-SimpleCov.start
+
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
+require 'sdr_client'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
## Why was this change made?

filters out coverage of the spec directory
and sets the test reporter id so results will be sent to codeclimate

Fixes #26

## Was the documentation (README, wiki) updated?
