### PR TITLE
Catkey is an optional argument

### DIFF
--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -7,7 +7,7 @@ module SdrClient
                  type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
                  apo:,
                  collection:,
-                 catkey:,
+                 catkey: nil,
                  source_id:,
                  url:, files: [])
 


### PR DESCRIPTION
## Why was this change made?

Otherwise you get an error if catkey is not provided.

## Was the documentation (README, wiki) updated?

n/a