### PR TITLE
Loosen faraday requirement

### DIFF
--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 0.17.0'
+  spec.add_dependency 'faraday', '>= 0.16'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
## Why was this change made?
This will allow it to work with google-books which requires faraday 0.16 or 1.0


## Was the documentation (README, wiki) updated?
n/a