### PR TITLE
Extract the strategy for dividing files into file_sets

### DIFF
--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -23,6 +23,7 @@ module SdrClient
   end
 end
 require 'json'
+require 'sdr_client/deposit/default_file_set_builder'
 require 'sdr_client/deposit/files/direct_upload_request'
 require 'sdr_client/deposit/files/direct_upload_response'
 require 'sdr_client/deposit/file'

--- a/lib/sdr_client/deposit/default_file_set_builder.rb
+++ b/lib/sdr_client/deposit/default_file_set_builder.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module SdrClient
+  module Deposit
+    # This stragegy is for building one file set per uploaded file
+    class DefaultFileSetBuilder
+      # @return [Request] request The initial request
+      # @param [Array<SdrClient::Deposit::Files::DirectUploadResponse>] uploads the uploaded files to attach.
+      # @return [Request] a clone of this request with the uploads added
+      def self.run(request:, uploads: [])
+        file_sets = uploads.each_with_index.map do |upload, i|
+          FileSet.new(uploads: [upload], label: "Object #{i + 1}")
+        end
+        request.with_file_sets(file_sets)
+      end
+    end
+  end
+end

--- a/lib/sdr_client/deposit/request.rb
+++ b/lib/sdr_client/deposit/request.rb
@@ -35,13 +35,8 @@ module SdrClient
         end
       end
 
-      # @param [Array<SdrClient::Deposit::Files::DirectUploadResponse>] uploads the uploaded files to attach.
-      # @return [Request] a clone of this request with the uploads added
-      def with_uploads(uploads)
-        file_sets = uploads.each_with_index.map do |upload, i|
-          FileSet.new(uploads: [upload], label: "Object #{i + 1}")
-        end
-
+      # @return [Request] a clone of this request with the file_sets added
+      def with_file_sets(file_sets)
         Request.new(label: label,
                     apo: apo,
                     collection: collection,
@@ -50,11 +45,6 @@ module SdrClient
                     type: type,
                     file_sets: file_sets)
       end
-
-      # In this case there is a 1-1 mapping between Files and FileSets,
-      # but this doesn't always have to be the case.  We could change this in the
-      # future so that we have one FileSet that has an Image and its OCR file.
-      def add_uploads_each_as_resource(uploads); end
 
       private
 

--- a/spec/sdr_client/deposit/request_spec.rb
+++ b/spec/sdr_client/deposit/request_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe SdrClient::Deposit::Request do
                         apo: 'druid:bc123df4567',
                         collection: 'druid:gh123df4567',
                         source_id: 'googlebooks:12345')
-                   .with_uploads([upload1, upload2])
+  end
+  let(:with_file_sets) do
+    SdrClient::Deposit::DefaultFileSetBuilder.run(request: instance, uploads: [upload1, upload2])
   end
 
   let(:upload1) do
@@ -31,7 +33,7 @@ RSpec.describe SdrClient::Deposit::Request do
   end
 
   describe 'as_json' do
-    subject { instance.as_json }
+    subject { with_file_sets.as_json }
     let(:expected) do
       {
         type: 'http://cocina.sul.stanford.edu/models/book.jsonld',


### PR DESCRIPTION
## Why was this change made?
So that we can add a new strategy for google books.
To support https://github.com/sul-dlss/google-books/issues/166

## Was the documentation (README, wiki) updated?
n/a