### PR TITLE
Add a way to group similarly named files into file sets

### DIFF
--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -24,6 +24,7 @@ module SdrClient
 end
 require 'json'
 require 'sdr_client/deposit/default_file_set_builder'
+require 'sdr_client/deposit/matching_file_set_builder'
 require 'sdr_client/deposit/files/direct_upload_request'
 require 'sdr_client/deposit/files/direct_upload_response'
 require 'sdr_client/deposit/file'

--- a/lib/sdr_client/deposit/default_file_set_builder.rb
+++ b/lib/sdr_client/deposit/default_file_set_builder.rb
@@ -4,14 +4,12 @@ module SdrClient
   module Deposit
     # This strategy is for building one file set per uploaded file
     class DefaultFileSetBuilder
-      # @return [Request] request The initial request
       # @param [Array<SdrClient::Deposit::Files::DirectUploadResponse>] uploads the uploaded files to attach.
-      # @return [Request] a clone of this request with the uploads added
-      def self.run(request:, uploads: [])
-        file_sets = uploads.each_with_index.map do |upload, i|
+      # @return [Array<SdrClient::Deposit::FileSet>] the uploads transformed to filesets
+      def self.run(uploads: [])
+        uploads.each_with_index.map do |upload, i|
           FileSet.new(uploads: [upload], label: "Object #{i + 1}")
         end
-        request.with_file_sets(file_sets)
       end
     end
   end

--- a/lib/sdr_client/deposit/matching_file_set_builder.rb
+++ b/lib/sdr_client/deposit/matching_file_set_builder.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SdrClient
+  module Deposit
+    # This stragegy is for building one file set per set of similarly prefixed uploaded files
+    class MatchingFileSetBuilder
+      # @return [Request] request The initial request
+      # @param [Array<SdrClient::Deposit::Files::DirectUploadResponse>] uploads the uploaded files to attach.
+      # @return [Request] a clone of this request with the uploads added
+      def self.run(request:, uploads: [])
+        grouped_files = uploads.group_by { |ul| ::File.basename(ul.filename, '.*') }.each_with_index
+        file_sets = grouped_files.map do |(_prefix, files), i|
+          SdrClient::Deposit::FileSet.new(uploads: files, label: "Object #{i + 1}")
+        end
+        request.with_file_sets(file_sets)
+      end
+    end
+  end
+end

--- a/lib/sdr_client/deposit/matching_file_set_builder.rb
+++ b/lib/sdr_client/deposit/matching_file_set_builder.rb
@@ -4,15 +4,13 @@ module SdrClient
   module Deposit
     # This stragegy is for building one file set per set of similarly prefixed uploaded files
     class MatchingFileSetBuilder
-      # @return [Request] request The initial request
       # @param [Array<SdrClient::Deposit::Files::DirectUploadResponse>] uploads the uploaded files to attach.
-      # @return [Request] a clone of this request with the uploads added
-      def self.run(request:, uploads: [])
+      # @return [Array<SdrClient::Deposit::FileSet>] the uploads transformed to filesets
+      def self.run(uploads: [])
         grouped_files = uploads.group_by { |ul| ::File.basename(ul.filename, '.*') }.each_with_index
-        file_sets = grouped_files.map do |(_prefix, files), i|
+        grouped_files.map do |(_prefix, files), i|
           SdrClient::Deposit::FileSet.new(uploads: files, label: "Object #{i + 1}")
         end
-        request.with_file_sets(file_sets)
       end
     end
   end

--- a/lib/sdr_client/deposit/process.rb
+++ b/lib/sdr_client/deposit/process.rb
@@ -29,7 +29,7 @@ module SdrClient
         file_metadata = collect_file_metadata
         upload_responses = upload_file_metadata(file_metadata)
         upload_files(upload_responses)
-        request = file_set_builder.run(request: metadata, uploads: upload_responses.values)
+        request = metadata.with_file_sets(file_set_builder.run(uploads: upload_responses.values))
         upload_metadata(request.as_json)
       end
 

--- a/spec/sdr_client/deposit/default_file_set_builder_spec.rb
+++ b/spec/sdr_client/deposit/default_file_set_builder_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe SdrClient::Deposit::DefaultFileSetBuilder do
+  let(:file_sets) { described_class.run(uploads: uploads) }
+  let(:initial_request) do
+    SdrClient::Deposit::Request.new(label: 'This is my object',
+                                    type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
+                                    source_id: 'googlebooks:12345',
+                                    collection: 'druid:gh123df4567',
+                                    apo: 'druid:bc123df4567')
+  end
+
+  let(:uploads) do
+    [
+      instance_double(SdrClient::Deposit::Files::DirectUploadResponse,
+                      filename: '00001.jp2',
+                      signed_id: 'xxxxx'),
+      instance_double(SdrClient::Deposit::Files::DirectUploadResponse,
+                      filename: '00001.html',
+                      signed_id: 'xxxxx'),
+      instance_double(SdrClient::Deposit::Files::DirectUploadResponse,
+                      filename: '00002.jp2',
+                      signed_id: 'xxxxx'),
+      instance_double(SdrClient::Deposit::Files::DirectUploadResponse,
+                      filename: '00002.html',
+                      signed_id: 'xxxxx'),
+      instance_double(SdrClient::Deposit::Files::DirectUploadResponse,
+                      filename: 'stanford_mets.xml',
+                      signed_id: 'xxxxx')
+    ]
+  end
+
+  it 'creates filesets' do
+    expect(file_sets.size).to eq 5
+  end
+end

--- a/spec/sdr_client/deposit/matching_file_set_builder_spec.rb
+++ b/spec/sdr_client/deposit/matching_file_set_builder_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe SdrClient::Deposit::MatchingFileSetBuilder do
+  let(:request) { described_class.run(request: initial_request, uploads: uploads) }
+  let(:initial_request) do
+    SdrClient::Deposit::Request.new(label: 'This is my object',
+                                    type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
+                                    source_id: 'googlebooks:12345',
+                                    collection: 'druid:gh123df4567',
+                                    apo: 'druid:bc123df4567')
+  end
+
+  let(:uploads) do
+    [
+      instance_double(SdrClient::Deposit::Files::DirectUploadResponse,
+                      filename: '00001.jp2',
+                      signed_id: 'xxxxx'),
+      instance_double(SdrClient::Deposit::Files::DirectUploadResponse,
+                      filename: '00001.html',
+                      signed_id: 'xxxxx'),
+      instance_double(SdrClient::Deposit::Files::DirectUploadResponse,
+                      filename: '00002.jp2',
+                      signed_id: 'xxxxx'),
+      instance_double(SdrClient::Deposit::Files::DirectUploadResponse,
+                      filename: '00002.html',
+                      signed_id: 'xxxxx'),
+      instance_double(SdrClient::Deposit::Files::DirectUploadResponse,
+                      filename: 'stanford_mets.xml',
+                      signed_id: 'xxxxx')
+    ]
+  end
+
+  it 'creates filesets' do
+    expect(request.as_json[:structural][:hasMember].size).to eq 3
+  end
+end

--- a/spec/sdr_client/deposit/matching_file_set_builder_spec.rb
+++ b/spec/sdr_client/deposit/matching_file_set_builder_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe SdrClient::Deposit::MatchingFileSetBuilder do
-  let(:request) { described_class.run(request: initial_request, uploads: uploads) }
+  let(:file_sets) { described_class.run(uploads: uploads) }
   let(:initial_request) do
     SdrClient::Deposit::Request.new(label: 'This is my object',
                                     type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
@@ -31,6 +31,6 @@ RSpec.describe SdrClient::Deposit::MatchingFileSetBuilder do
   end
 
   it 'creates filesets' do
-    expect(request.as_json[:structural][:hasMember].size).to eq 3
+    expect(file_sets.size).to eq 3
   end
 end

--- a/spec/sdr_client/deposit/request_spec.rb
+++ b/spec/sdr_client/deposit/request_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe SdrClient::Deposit::Request do
                         source_id: 'googlebooks:12345')
   end
   let(:with_file_sets) do
-    SdrClient::Deposit::DefaultFileSetBuilder.run(request: instance, uploads: [upload1, upload2])
+    instance.with_file_sets(file_set_builder)
+  end
+
+  let(:file_set_builder) do
+    SdrClient::Deposit::DefaultFileSetBuilder.run(uploads: [upload1, upload2])
   end
 
   let(:upload1) do


### PR DESCRIPTION
## Why was this change made?

So we can group a page image with it's OCR into a fileset.

## Was the documentation (README, wiki) updated?
n/a