### PR TITLE
rename hasMember -> contains

### DIFF
--- a/lib/sdr_client/deposit/file_set.rb
+++ b/lib/sdr_client/deposit/file_set.rb
@@ -20,7 +20,7 @@ module SdrClient
           "type": 'http://cocina.sul.stanford.edu/models/fileset.jsonld',
           "label": label,
           structural: {
-            hasMember: files.map(&:as_json)
+            contains: files.map(&:as_json)
           }
         }
       end

--- a/lib/sdr_client/deposit/request.rb
+++ b/lib/sdr_client/deposit/request.rb
@@ -67,7 +67,7 @@ module SdrClient
       def structural
         {
           isMemberOf: collection,
-          hasMember: file_sets.map(&:as_json)
+          contains: file_sets.map(&:as_json)
         }
       end
     end

--- a/spec/sdr_client/deposit/process_spec.rb
+++ b/spec/sdr_client/deposit/process_spec.rb
@@ -95,14 +95,14 @@ RSpec.describe SdrClient::Deposit::Process do
               '"administrative":{"hasAdminPolicy":"druid:bc123df4567"},' \
               '"identification":{"sourceId":"googlebooks:12345"},' \
               '"structural":{"isMemberOf":"druid:gh123df4567",' \
-              '"hasMember":[{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld",' \
+              '"contains":[{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld",' \
               '"label":"Object 1",' \
-              '"structural":{"hasMember":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \
+              '"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \
               '"label":"file1.txt","filename":"file1.txt","externalIdentifier":"BaHBLZz09Iiw",' \
               '"access":{"access":"dark"},"administrative":{"sdrPreserve":false,"shelve":false}}]}},' \
               '{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld",' \
               '"label":"Object 2",' \
-              '"structural":{"hasMember":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \
+              '"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \
               '"label":"file2.txt","filename":"file2.txt","externalIdentifier":"dz09IiwiZXhwIjpudWxsLC",' \
               '"access":{"access":"dark"},"administrative":{"sdrPreserve":false,"shelve":false}}]}}]},' \
               '"label":"This is my object"}',
@@ -139,16 +139,16 @@ RSpec.describe SdrClient::Deposit::Process do
           '"administrative":{"hasAdminPolicy":"druid:bc123df4567"},' \
           '"identification":{"sourceId":"googlebooks:12345"},' \
           '"structural":{"isMemberOf":"druid:gh123df4567",' \
-          '"hasMember":[{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld",' \
+          '"contains":[{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld",' \
           '"label":"Object 1",' \
-          '"structural":{"hasMember":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \
+          '"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \
           '"label":"file1.txt","filename":"file1.txt","externalIdentifier":"BaHBLZz09Iiw",' \
           '"access":{"access":"public"},"administrative":{"sdrPreserve":true,"shelve":true},' \
           '"hasMessageDigests":[{"type":"md5","digest":"abc123"},{"type":"sha1","digest":"def456"}],' \
           '"hasMimeType":"image/tiff"}]}},' \
           '{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld",' \
           '"label":"Object 2",' \
-          '"structural":{"hasMember":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \
+          '"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \
           '"label":"file2.txt","filename":"file2.txt","externalIdentifier":"dz09IiwiZXhwIjpudWxsLC",' \
           '"access":{"access":"dark"},"administrative":{"sdrPreserve":false,"shelve":false}}]}}]},' \
           '"label":"This is my object"}',

--- a/spec/sdr_client/deposit/request_spec.rb
+++ b/spec/sdr_client/deposit/request_spec.rb
@@ -50,11 +50,11 @@ RSpec.describe SdrClient::Deposit::Request do
         identification: { sourceId: 'googlebooks:12345' },
         structural: {
           isMemberOf: 'druid:gh123df4567',
-          hasMember: [
+          contains: [
             {
               type: 'http://cocina.sul.stanford.edu/models/fileset.jsonld',
               label: 'Object 1',
-              structural: { hasMember:
+              structural: { contains:
                 [
                   {
                     type: 'http://cocina.sul.stanford.edu/models/file.jsonld',
@@ -68,7 +68,7 @@ RSpec.describe SdrClient::Deposit::Request do
             {
               type: 'http://cocina.sul.stanford.edu/models/fileset.jsonld',
               label: 'Object 2',
-              structural: { hasMember:
+              structural: { contains:
                 [
                   {
                     type: 'http://cocina.sul.stanford.edu/models/file.jsonld',


### PR DESCRIPTION
## Why was this change made?
This follows the documented json schema in https://github.com/sul-dlss/cocina-models/blame/master/docs/maps


Required for https://github.com/sul-dlss/sdr-api/pull/107


## Was the documentation (README, wiki) updated?
n/a