### PR TITLE
Allow injection of file metadata in `SdrClient::Deposit`

### DIFF
--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -12,6 +12,7 @@ module SdrClient
                  source_id:,
                  url:,
                  files: [],
+                 files_metadata: {},
                  grouping_strategy: SingleFileGroupingStrategy)
       token = Credentials.read
 
@@ -21,7 +22,8 @@ module SdrClient
                              collection: collection,
                              source_id: source_id,
                              catkey: catkey)
-      Process.new(metadata: metadata, url: url, token: token, files: files, grouping_strategy: grouping_strategy).run
+      Process.new(metadata: metadata, url: url, token: token,
+                  files: files, files_metadata: files_metadata, grouping_strategy: grouping_strategy).run
     end
     # rubocop:enable Metrics/ParameterLists
   end

--- a/lib/sdr_client/deposit/matching_file_grouping_strategy.rb
+++ b/lib/sdr_client/deposit/matching_file_grouping_strategy.rb
@@ -7,7 +7,10 @@ module SdrClient
       # @param [Array<SdrClient::Deposit::Files::DirectUploadResponse>] uploads the uploaded files to attach.
       # @return [Array<Array<SdrClient::Deposit::Files::DirectUploadResponse>>] uploads the grouped uploaded files.
       def self.run(uploads: [])
-        uploads.group_by { |ul| ::File.basename(ul.filename, '.*') }
+        # Call `#values` on the result of the grouping operation because 1)
+        # `Process#build_filesets` expects an array of arrays, not an array of
+        # hashes, and 2) the keys aren't used anywhere
+        uploads.group_by { |ul| ::File.basename(ul.filename, '.*') }.values
       end
     end
   end

--- a/lib/sdr_client/deposit/process.rb
+++ b/lib/sdr_client/deposit/process.rb
@@ -126,10 +126,10 @@ module SdrClient
       # @return [Array<SdrClient::Deposit::FileSet>] the uploads transformed to filesets
       def build_filesets(uploads:, files_metadata:)
         grouped_uploads = grouping_strategy.run(uploads: uploads)
-        grouped_uploads.each_with_index.map do |upload_group, i|
+        grouped_uploads.map.with_index(1) do |upload_group, i|
           metadata_group = {}
           upload_group.each { |upload| metadata_group[upload.filename] = files_metadata.fetch(upload.filename, {}) }
-          FileSet.new(uploads: upload_group, uploads_metadata: metadata_group, label: "Object #{i + 1}")
+          FileSet.new(uploads: upload_group, uploads_metadata: metadata_group, label: "Object #{i}")
         end
       end
     end


### PR DESCRIPTION
Unblocks sul-dlss/google-books#168
Fixes #53

## Why was this change made?

So that `SdrClient::Deposit::Process` passes along file metadata, including mime types, down through `SdrClient::Deposit::FileSet` to `SdrClient::Deposit::File`.

## Was the documentation (README, wiki) updated?

no