### PR TITLE
Allow logger to be set for Deposit.

### DIFF
--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'logger'
+
 module SdrClient
   # The namespace for the "deposit" command
   module Deposit
@@ -13,7 +15,8 @@ module SdrClient
                  url:,
                  files: [],
                  files_metadata: {},
-                 grouping_strategy: SingleFileGroupingStrategy)
+                 grouping_strategy: SingleFileGroupingStrategy,
+                 logger: Logger.new(STDOUT))
       token = Credentials.read
 
       metadata = Request.new(label: label,
@@ -22,8 +25,8 @@ module SdrClient
                              collection: collection,
                              source_id: source_id,
                              catkey: catkey)
-      Process.new(metadata: metadata, url: url, token: token,
-                  files: files, files_metadata: files_metadata, grouping_strategy: grouping_strategy).run
+      Process.new(metadata: metadata, url: url, token: token, files: files,
+                  files_metadata: files_metadata, grouping_strategy: grouping_strategy, logger: logger).run
     end
     # rubocop:enable Metrics/ParameterLists
   end

--- a/spec/sdr_client/deposit_spec.rb
+++ b/spec/sdr_client/deposit_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe SdrClient::Deposit do
                 files_metadata: {},
                 metadata: request,
                 token: 'token',
-                url: 'http://example.com/')
+                url: 'http://example.com/',
+                logger: Logger)
 
         expect(process).to have_received(:run)
       end
@@ -93,7 +94,8 @@ RSpec.describe SdrClient::Deposit do
                 files_metadata: {},
                 metadata: request,
                 token: 'token',
-                url: 'http://example.com/')
+                url: 'http://example.com/',
+                logger: Logger)
 
         expect(process).to have_received(:run)
       end


### PR DESCRIPTION
refs https://github.com/sul-dlss/google-books/issues/209

## Why was this change made?
So that the logger can be set from outside the client.


## Was the documentation (README, wiki) updated?
No.