### PR TITLE
Remove mime type from sdr-client

### DIFF
--- a/lib/sdr_client/deposit/file.rb
+++ b/lib/sdr_client/deposit/file.rb
@@ -7,14 +7,13 @@ module SdrClient
       # rubocop:disable Metrics/ParameterLists
       def initialize(external_identifier:, label:, filename:,
                      access: 'dark', preserve: false, shelve: false,
-                     mime_type: nil, md5: nil, sha1: nil)
+                     md5: nil, sha1: nil)
         @external_identifier = external_identifier
         @label = label
         @filename = filename
         @access = access
         @preserve = preserve
         @shelve = shelve
-        @mime_type = mime_type
         @md5 = md5
         @sha1 = sha1
       end
@@ -36,7 +35,6 @@ module SdrClient
           }
         }.tap do |json|
           json['hasMessageDigests'] = message_digests unless message_digests.empty?
-          json['hasMimeType'] = @mime_type if @mime_type
         end
       end
       # rubocop:enable Metrics/MethodLength

--- a/spec/sdr_client/deposit/process_spec.rb
+++ b/spec/sdr_client/deposit/process_spec.rb
@@ -124,7 +124,6 @@ RSpec.describe SdrClient::Deposit::Process do
             'file1.txt' => {
               md5: 'abc123',
               sha1: 'def456',
-              mime_type: 'image/tiff',
               access: 'public',
               preserve: true,
               shelve: true
@@ -144,8 +143,7 @@ RSpec.describe SdrClient::Deposit::Process do
           '"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \
           '"label":"file1.txt","filename":"file1.txt","externalIdentifier":"BaHBLZz09Iiw",' \
           '"access":{"access":"public"},"administrative":{"sdrPreserve":true,"shelve":true},' \
-          '"hasMessageDigests":[{"type":"md5","digest":"abc123"},{"type":"sha1","digest":"def456"}],' \
-          '"hasMimeType":"image/tiff"}]}},' \
+          '"hasMessageDigests":[{"type":"md5","digest":"abc123"},{"type":"sha1","digest":"def456"}]}]}},' \
           '{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld",' \
           '"label":"Object 2",' \
           '"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \

--- a/spec/sdr_client/deposit_spec.rb
+++ b/spec/sdr_client/deposit_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe SdrClient::Deposit do
         external_identifier: 'BaHBLZz09Iiw',
         filename: 'file1.txt',
         label: 'file1.txt',
-        mime_type: 'text/plain'
+        md5: 'foobar',
+        sha1: 'bazquux'
       ).and_call_original
       described_class.run(apo: 'druid:bc123df4567',
                           collection: 'druid:gh123df4567',
@@ -36,7 +37,8 @@ RSpec.describe SdrClient::Deposit do
                           files: ['spec/fixtures/file1.txt'],
                           files_metadata: {
                             'file1.txt' => {
-                              mime_type: 'text/plain'
+                              md5: 'foobar',
+                              sha1: 'bazquux'
                             }
                           },
                           grouping_strategy: SdrClient::Deposit::MatchingFileGroupingStrategy)


### PR DESCRIPTION
Connects to sul-dlss/sdr-api#109

## Why was this change made?

This ability is moving into sdr-api and is longer expected to be set upstream of the API.

## Was the documentation (README, wiki) updated?

no