### PR TITLE
Removes puts from credentials.rb.

### DIFF
--- a/lib/sdr_client/cli.rb
+++ b/lib/sdr_client/cli.rb
@@ -13,6 +13,9 @@ module SdrClient
       else
         raise "Unknown command #{command}"
       end
+    rescue SdrClient::Credentials::NoCredentialsError
+      puts 'Log in first'
+      exit(1)
     end
   end
 end

--- a/lib/sdr_client/credentials.rb
+++ b/lib/sdr_client/credentials.rb
@@ -3,6 +3,8 @@
 module SdrClient
   # The stored credentials
   class Credentials
+    class NoCredentialsError < StandardError; end
+
     # @param [String] a json string that contains a field 'token'
     def self.write(body)
       json = JSON.parse(body)
@@ -10,14 +12,12 @@ module SdrClient
       File.open(credentials_file, 'w', 0o600) do |file|
         file.write(json.fetch('token'))
       end
-      puts 'Signed in.'
     end
 
     def self.read
-      return IO.readlines(credentials_file, chomp: true).first if ::File.exist?(credentials_file)
+      raise NoCredentialsError unless ::File.exist?(credentials_file)
 
-      puts 'Log in first'
-      exit(1)
+      IO.readlines(credentials_file, chomp: true).first
     end
 
     def self.credentials_path

--- a/spec/sdr_client/credentials_spec.rb
+++ b/spec/sdr_client/credentials_spec.rb
@@ -20,9 +20,8 @@ RSpec.describe SdrClient::Credentials do
       before do
         allow(described_class).to receive(:credentials_path).and_return('/nonexistant')
       end
-      it 'exits' do
-        expect { subject }.to raise_error(SystemExit)
-          .and output("Log in first\n").to_stdout
+      it 'raises' do
+        expect { subject }.to raise_error(SdrClient::Credentials::NoCredentialsError)
       end
     end
   end


### PR DESCRIPTION
closes #57

## Why was this change made?
So that messages aren't written to stdout when using as a library.


## Was the documentation (README, wiki) updated?
No.