### PR TITLE
Make file_metadata part of the request

### DIFF
--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -24,9 +24,10 @@ module SdrClient
                              apo: apo,
                              collection: collection,
                              source_id: source_id,
-                             catkey: catkey)
+                             catkey: catkey,
+                             files_metadata: files_metadata)
       Process.new(metadata: metadata, url: url, token: token, files: files,
-                  files_metadata: files_metadata, grouping_strategy: grouping_strategy, logger: logger).run
+                  grouping_strategy: grouping_strategy, logger: logger).run
     end
     # rubocop:enable Metrics/ParameterLists
   end

--- a/lib/sdr_client/deposit/metadata_builder.rb
+++ b/lib/sdr_client/deposit/metadata_builder.rb
@@ -8,14 +8,12 @@ module SdrClient
     class MetadataBuilder
       # @param [Request] metadata information about the object
       # @param [Class] grouping_strategy class whose run method groups an array of uploads
-      # @param [Hash<String, Hash<String, String>>] files_metadata file name, hash of additional file metadata
       # Additional metadata includes access, preserve, shelve, md5, sha1
       # @param [Logger] logger the logger to use
-      def initialize(metadata:, grouping_strategy:, files_metadata:, logger:)
+      def initialize(metadata:, grouping_strategy:, logger:)
         @metadata = metadata
         @logger = logger
         @grouping_strategy = grouping_strategy
-        @files_metadata = files_metadata
       end
 
       def with_uploads(upload_responses)
@@ -25,7 +23,7 @@ module SdrClient
 
       private
 
-      attr_reader :metadata, :files, :logger, :grouping_strategy, :files_metadata
+      attr_reader :metadata, :files, :logger, :grouping_strategy
 
       # @param [Array<SdrClient::Deposit::Files::DirectUploadResponse>] uploads the uploaded files to attach.
       # @return [Array<SdrClient::Deposit::FileSet>] the uploads transformed to filesets
@@ -33,7 +31,7 @@ module SdrClient
         grouped_uploads = grouping_strategy.run(uploads: uploads)
         grouped_uploads.map.with_index(1) do |upload_group, i|
           metadata_group = {}
-          upload_group.each { |upload| metadata_group[upload.filename] = files_metadata.fetch(upload.filename, {}) }
+          upload_group.each { |upload| metadata_group[upload.filename] = metadata.for(upload.filename) }
           FileSet.new(uploads: upload_group, uploads_metadata: metadata_group, label: "Object #{i}")
         end
       end

--- a/lib/sdr_client/deposit/request.rb
+++ b/lib/sdr_client/deposit/request.rb
@@ -7,6 +7,8 @@ module SdrClient
       # @param [String] label the required object label
       # @param [String] type (http://cocina.sul.stanford.edu/models/object.jsonld) the required object type.
       # @param [Array<FileSet>] file_sets the file sets to attach.
+      # @param [Hash<String, Hash<String, String>>] files_metadata file name, hash of additional file metadata
+      # Additional metadata includes access, preserve, shelve, md5, sha1
       # rubocop:disable Metrics/ParameterLists
       def initialize(label: nil,
                      apo:,
@@ -14,7 +16,8 @@ module SdrClient
                      source_id:,
                      catkey: nil,
                      type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
-                     file_sets: [])
+                     file_sets: [],
+                     files_metadata: {})
         @label = label
         @type = type
         @source_id = source_id
@@ -22,6 +25,7 @@ module SdrClient
         @catkey = catkey
         @apo = apo
         @file_sets = file_sets
+        @files_metadata = files_metadata
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -45,12 +49,20 @@ module SdrClient
                     source_id: source_id,
                     catkey: catkey,
                     type: type,
-                    file_sets: file_sets)
+                    file_sets: file_sets,
+                    files_metadata: files_metadata)
+      end
+
+      # @param [String] filename
+      # @return [Hash] the metadata for the file
+      def for(filename)
+        files_metadata.fetch(filename, {})
       end
 
       private
 
-      attr_reader :label, :file_sets, :source_id, :catkey, :apo, :collection, :type
+      attr_reader :label, :file_sets, :source_id, :catkey, :apo, :collection,
+                  :type, :files_metadata
 
       def administrative
         {

--- a/lib/sdr_client/deposit/upload_files.rb
+++ b/lib/sdr_client/deposit/upload_files.rb
@@ -10,10 +10,10 @@ module SdrClient
       # @param [Array<String>] files a list of file names to upload
       # @param [Logger] logger the logger to use
       # @param [Faraday::Connection] connection
-      # @param [Hash<String, Hash<String, String>>] files_metadata file name, hash of additional file metadata
-      def initialize(files:, files_metadata:, logger:, connection:)
+      # @param [Request] metadata information about the object
+      def initialize(files:, metadata:, logger:, connection:)
         @files = files
-        @files_metadata = files_metadata
+        @metadata = metadata
         @logger = logger
         @connection = connection
       end
@@ -28,14 +28,14 @@ module SdrClient
 
       private
 
-      attr_reader :files, :files_metadata, :logger, :connection
+      attr_reader :files, :metadata, :logger, :connection
 
       def collect_file_metadata
         files.each_with_object({}) do |path, obj|
           file_name = ::File.basename(path)
           obj[path] = Files::DirectUploadRequest.from_file(path,
                                                            file_name: file_name,
-                                                           content_type: file_metadata_for(file_name)[:mime_type])
+                                                           content_type: metadata.for(file_name)[:mime_type])
         end
       end
 
@@ -76,11 +76,6 @@ module SdrClient
         end
 
         raise "unexpected response: #{upload_response.inspect}" unless upload_response.status == 204
-      end
-
-      # @return [Hash<Symbol,String>] the file metadata for this file
-      def file_metadata_for(filename)
-        files_metadata.fetch(filename, {})
       end
     end
   end

--- a/spec/sdr_client/deposit/process_spec.rb
+++ b/spec/sdr_client/deposit/process_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe SdrClient::Deposit::Process do
                                     type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
                                     apo: 'druid:bc123df4567',
                                     collection: 'druid:gh123df4567',
-                                    source_id: 'googlebooks:12345')
+                                    source_id: 'googlebooks:12345',
+                                    files_metadata: files_metadata)
   end
 
   let(:instance) do
@@ -14,8 +15,7 @@ RSpec.describe SdrClient::Deposit::Process do
                         url: 'http://example.com:3000',
                         token: 'eyJhbGci',
                         files: files,
-                        logger: logger,
-                        files_metadata: files_metadata)
+                        logger: logger)
   end
 
   let(:logger) { instance_double(Logger, info: nil) }

--- a/spec/sdr_client/deposit_spec.rb
+++ b/spec/sdr_client/deposit_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe SdrClient::Deposit do
         expect(SdrClient::Deposit::Process).to have_received(:new)
           .with(grouping_strategy: SdrClient::Deposit::SingleFileGroupingStrategy,
                 files: [],
-                files_metadata: {},
                 metadata: request,
                 token: 'token',
                 url: 'http://example.com/',
@@ -91,7 +90,6 @@ RSpec.describe SdrClient::Deposit do
         expect(SdrClient::Deposit::Process).to have_received(:new)
           .with(grouping_strategy: SdrClient::Deposit::MatchingFileGroupingStrategy,
                 files: [],
-                files_metadata: {},
                 metadata: request,
                 token: 'token',
                 url: 'http://example.com/',


### PR DESCRIPTION


## Why was this change made?

This is the object that has the other metadata, so it makes sense to keep it together.

## Was the documentation (README, wiki) updated?
n/a