### PR TITLE
Adds new use attribute for Deposit::File

### DIFF
--- a/lib/sdr_client/deposit/file.rb
+++ b/lib/sdr_client/deposit/file.rb
@@ -7,7 +7,7 @@ module SdrClient
       # rubocop:disable Metrics/ParameterLists
       def initialize(external_identifier:, label:, filename:,
                      access: 'dark', preserve: false, shelve: false,
-                     mime_type: nil, md5: nil, sha1: nil)
+                     mime_type: nil, md5: nil, sha1: nil, use: nil)
         @external_identifier = external_identifier
         @label = label
         @filename = filename
@@ -17,6 +17,7 @@ module SdrClient
         @mime_type = mime_type
         @md5 = md5
         @sha1 = sha1
+        @use = use
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -37,6 +38,7 @@ module SdrClient
         }.tap do |json|
           json['hasMessageDigests'] = message_digests unless message_digests.empty?
           json['hasMimeType'] = @mime_type if @mime_type
+          json['use'] = @use if @use
         end
       end
       # rubocop:enable Metrics/MethodLength

--- a/spec/sdr_client/deposit_spec.rb
+++ b/spec/sdr_client/deposit_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe SdrClient::Deposit do
         external_identifier: 'BaHBLZz09Iiw',
         filename: 'file1.txt',
         label: 'file1.txt',
-        mime_type: 'text/plain'
+        mime_type: 'text/plain',
+        use: 'transcription'
       ).and_call_original
       described_class.run(apo: 'druid:bc123df4567',
                           collection: 'druid:gh123df4567',
@@ -36,7 +37,8 @@ RSpec.describe SdrClient::Deposit do
                           files: ['spec/fixtures/file1.txt'],
                           files_metadata: {
                             'file1.txt' => {
-                              mime_type: 'text/plain'
+                              mime_type: 'text/plain',
+                              use: 'transcription'
                             }
                           },
                           grouping_strategy: SdrClient::Deposit::MatchingFileGroupingStrategy)


### PR DESCRIPTION
## Why was this change made?
Supports sending a `SdrClient::Deposit::File`'s use attribute for Google Book's issue [197](https://github.com/sul-dlss/google-books/issues/197)


## Was the documentation (README, wiki) updated?
n/a