### PR TITLE
Handles 401.

### DIFF
--- a/lib/sdr_client/deposit/process.rb
+++ b/lib/sdr_client/deposit/process.rb
@@ -62,10 +62,10 @@ module SdrClient
       end
 
       def unexpected_response(response)
-        raise "unexpected response: #{response.inspect}" unless response.status == 400
+        raise "There was an error with your request: #{response.body}" if response.status == 400
+        raise 'There was an error with your credentials. Perhaps they have expired?' if response.status == 401
 
-        puts "\nThere was an error with your request: #{response.body}"
-        exit(1)
+        raise "unexpected response: #{response.inspect}"
       end
 
       def connection

--- a/lib/sdr_client/deposit/upload_files.rb
+++ b/lib/sdr_client/deposit/upload_files.rb
@@ -47,11 +47,17 @@ module SdrClient
       def direct_upload(metadata_json)
         logger.info("Starting an upload request: #{metadata_json}")
         response = connection.post(BLOB_PATH, metadata_json, 'Content-Type' => 'application/json')
-        raise "unexpected response: #{response.inspect}" unless response.status == 200
+        unexpected_response(response) unless response.status == 200
 
         logger.info("Response from server: #{response.body}")
 
         Files::DirectUploadResponse.new(JSON.parse(response.body))
+      end
+
+      def unexpected_response(response)
+        raise 'There was an error with your credentials. Perhaps they have expired?' if response.status == 401
+
+        raise "unexpected response: #{response.inspect}"
       end
 
       # @param [Hash<String,Files::DirectUploadResponse>] upload_responses the filenames and their upload response

--- a/spec/sdr_client/deposit/process_spec.rb
+++ b/spec/sdr_client/deposit/process_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe SdrClient::Deposit::Process do
         end
       end
 
-      context 'when metadata upload fails' do
+      context 'when metadata upload fails with bad request' do
         before do
           stub_request(:post, 'http://example.com:3000/v1/direct_uploads')
             .with(
@@ -275,10 +275,68 @@ RSpec.describe SdrClient::Deposit::Process do
         end
 
         it 'uploads files' do
-          expect { subject }.to raise_error(SystemExit)
-            .and output("\nThere was an error with your request: " \
-              '{"id":"bad_request","message":"#/components/schemas/DROStructural ' \
-              "missing required parameters: isMemberOf\"}\n").to_stdout
+          expect { subject }.to raise_error(/There was an error with your request/)
+        end
+      end
+
+      context 'when metadata upload fails with unauthorized' do
+        before do
+          stub_request(:post, 'http://example.com:3000/v1/direct_uploads')
+            .with(
+              body: '{"blob":{"filename":"file1.txt","byte_size":27,"checksum":"hagfaf2F1Cx0r3jnHtIe9Q==",'\
+                '"content_type":"application/octet-stream"}}',
+              headers: { 'Content-Type' => 'application/json' }
+            )
+            .to_return(status: 200,
+                       body: '{"id":37,"key":"gugv9ii3e79k933cjv36x732497s","filename":"file1.txt",'\
+                             '"content_type":"application/octet-stream","metadata":{},"byte_size":27,' \
+                             '"checksum":"hagfaf2F1Cx0r3jnHtIe9Q==","created_at":"2019-11-16T21:36:03.122Z",'\
+                             '"signed_id":"BaHBLZz09Iiw",'\
+                             '"direct_upload":{"url":"' + upload_url1 + '",'\
+                             '"headers":{"Content-Type":"application/octet-stream"}}}',
+                       headers: {})
+
+          stub_request(:post, 'http://example.com:3000/v1/direct_uploads')
+            .with(
+              body: '{"blob":{"filename":"file2.txt","byte_size":36,"checksum":"LzYE2VS+iI3+Wx65v2MJ5A==",'\
+                '"content_type":"application/octet-stream"}}',
+              headers: { 'Content-Type' => 'application/json' }
+            )
+            .to_return(status: 200,
+                       body: '{"id":38,"key":"08y78dduz8w077l3lbcrrd5vjk4x","filename":"file2.txt",'\
+                             '"content_type":"application/octet-stream","metadata":{},"byte_size":36,'\
+                             '"checksum":"LzYE2VS+iI3+Wx65v2MJ5A==","created_at":"2019-11-16T21:37:16.657Z",'\
+                             '"signed_id":"dz09IiwiZXhwIjpudWxsLC",'\
+                             '"direct_upload":{"url":"' + upload_url2 + '",'\
+                             '"headers":{"Content-Type":"application/octet-stream"}}}',
+                       headers: {})
+
+          stub_request(:put, upload_url1)
+            .with(
+              body: "This is a fixture file ...\n",
+              headers: {
+                'Content-Length' => '27',
+                'Content-Type' => 'application/octet-stream'
+              }
+            )
+            .to_return(status: 204)
+
+          stub_request(:put, upload_url2)
+            .with(
+              body: "This is a fixture file for testing.\n",
+              headers: {
+                'Content-Length' => '36',
+                'Content-Type' => 'application/octet-stream'
+              }
+            )
+            .to_return(status: 204)
+
+          stub_request(:post, 'http://example.com:3000/v1/resources')
+            .to_return(status: 401)
+        end
+
+        it 'uploads files' do
+          expect { subject }.to raise_error(/There was an error with your credentials./)
         end
       end
     end


### PR DESCRIPTION
closes #34

## Why was this change made?
So that the user got a more friendly error when 401.


## Was the documentation (README, wiki) updated?
No.