### PR TITLE
API client should set a viewingDirection

### DIFF
--- a/exe/sdr
+++ b/exe/sdr
@@ -62,6 +62,11 @@ subcommands = {
       options[:source_id] = source_id
     end
 
+    opts.on('--viewing-direction DIRECTION', 'The viewing direction (if a book). ' \
+            'Either "left-to-right" or "right-to-left"') do |viewing_direction|
+      options[:viewing_direction] = viewing_direction if %w[left-to-right right-to-left].include?(viewing_direction)
+    end
+
     opts.on('--files-metadata FILES_METADATA', 'A JSON object representing per-file metadata') do |files_metadata|
       options[:files_metadata] = JSON.parse(files_metadata)
     end

--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -8,6 +8,7 @@ module SdrClient
     # rubocop:disable Metrics/ParameterLists
     def self.run(label: nil,
                  type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
+                 viewing_direction: nil,
                  apo:,
                  collection: nil,
                  catkey: nil,
@@ -29,6 +30,7 @@ module SdrClient
                              catkey: catkey,
                              embargo_release_date: embargo_release_date,
                              embargo_access: embargo_access,
+                             viewing_direction: viewing_direction,
                              files_metadata: files_metadata)
       Process.new(metadata: metadata, url: url, token: token, files: files,
                   grouping_strategy: grouping_strategy, logger: logger).run

--- a/lib/sdr_client/deposit/request.rb
+++ b/lib/sdr_client/deposit/request.rb
@@ -20,6 +20,7 @@ module SdrClient
                      embargo_release_date: nil,
                      embargo_access: 'world',
                      type: 'http://cocina.sul.stanford.edu/models/object.jsonld',
+                     viewing_direction: nil,
                      file_sets: [],
                      files_metadata: {})
         @label = label
@@ -32,6 +33,7 @@ module SdrClient
         @apo = apo
         @file_sets = file_sets
         @files_metadata = files_metadata
+        @viewing_direction = viewing_direction
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -57,6 +59,7 @@ module SdrClient
                     embargo_release_date: embargo_release_date,
                     embargo_access: embargo_access,
                     type: type,
+                    viewing_direction: viewing_direction,
                     file_sets: file_sets,
                     files_metadata: files_metadata)
       end
@@ -70,7 +73,8 @@ module SdrClient
       private
 
       attr_reader :label, :file_sets, :source_id, :catkey, :apo, :collection,
-                  :type, :files_metadata, :embargo_release_date, :embargo_access
+                  :type, :files_metadata, :embargo_release_date, :embargo_access,
+                  :viewing_direction
 
       def administrative
         {
@@ -88,6 +92,7 @@ module SdrClient
         {}.tap do |json|
           json[:isMemberOf] = collection if collection
           json[:contains] = file_sets.map(&:as_json) unless file_sets.empty?
+          json[:hasMemberOrders] = [{ viewing_direction: viewing_direction }] if viewing_direction
         end
       end
 

--- a/spec/sdr_client/deposit_spec.rb
+++ b/spec/sdr_client/deposit_spec.rb
@@ -100,5 +100,35 @@ RSpec.describe SdrClient::Deposit do
         expect(process).to have_received(:run)
       end
     end
+
+    context 'with a viewing_direction' do
+      subject(:run) do
+        described_class.run(apo: 'druid:bc123df4567',
+                            collection: 'druid:gh123df4567',
+                            source_id: 'googlebooks:12345',
+                            url: 'http://example.com/',
+                            viewing_direction: 'left-to-right',
+                            grouping_strategy: SdrClient::Deposit::MatchingFileGroupingStrategy)
+      end
+
+      it 'runs the process with the specified grouping_strategy' do
+        run
+        expect(SdrClient::Deposit::Request).to have_received(:new)
+          .with(
+            apo: 'druid:bc123df4567',
+            catkey: nil,
+            collection: 'druid:gh123df4567',
+            embargo_access: 'world',
+            embargo_release_date: nil,
+            files_metadata: {},
+            label: nil,
+            source_id: 'googlebooks:12345',
+            type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
+            viewing_direction: 'left-to-right'
+          )
+
+        expect(process).to have_received(:run)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

So that we can pass the viewing direction from google-books.


## Was the documentation (README, wiki) updated?
n/a