### PR TITLE
Log an error with status code and body

### DIFF
--- a/lib/sdr_client/deposit/process.rb
+++ b/lib/sdr_client/deposit/process.rb
@@ -65,7 +65,7 @@ module SdrClient
         raise "There was an error with your request: #{response.body}" if response.status == 400
         raise 'There was an error with your credentials. Perhaps they have expired?' if response.status == 401
 
-        raise "unexpected response: #{response.inspect}"
+        raise "unexpected response: #{response.status} #{response.body}"
       end
 
       def connection


### PR DESCRIPTION
## Why was this change made?

Inspecting the Faraday::Response results in too long of a message as it has the entire request present
Ref sul-dlss/google-books#308
## Was the documentation (README, wiki) updated?
n/a