### PR TITLE
Copy copyright and use_statement when adding filesets

### DIFF
--- a/lib/sdr_client/deposit/request.rb
+++ b/lib/sdr_client/deposit/request.rb
@@ -61,11 +61,13 @@ module SdrClient
                     access: access,
                     apo: apo,
                     collection: collection,
+                    copyright: copyright,
                     source_id: source_id,
                     catkey: catkey,
                     embargo_release_date: embargo_release_date,
                     embargo_access: embargo_access,
                     type: type,
+                    use_statement: use_statement,
                     viewing_direction: viewing_direction,
                     file_sets: file_sets,
                     files_metadata: files_metadata)

--- a/spec/sdr_client/deposit/request_spec.rb
+++ b/spec/sdr_client/deposit/request_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe SdrClient::Deposit::Request do
                           type: 'http://cocina.sul.stanford.edu/models/book.jsonld',
                           apo: 'druid:bc123df4567',
                           collection: 'druid:gh123df4567',
+                          copyright: 'copyright',
                           source_id: 'googlebooks:12345',
                           catkey: '11991',
+                          use_statement: 'use statement',
                           viewing_direction: 'right-to-left',
                           embargo_release_date: Time.gm(2045),
                           embargo_access: 'stanford')
@@ -52,6 +54,8 @@ RSpec.describe SdrClient::Deposit::Request do
           label: 'This is my object',
           access: {
             access: 'dark',
+            copyright: 'copyright',
+            useAndReproductionStatement: 'use statement',
             embargo: {
               releaseDate: '2045-01-01T00:00:00+00:00',
               access: 'stanford'


### PR DESCRIPTION
## Why was this change made?

Adding filesets to the request was clearing out the use_statement and copyright.

## Was the documentation (README, wiki) updated?
n/a