### PR TITLE
File metadata has string keys

### DIFF
--- a/lib/sdr_client/deposit/upload_files.rb
+++ b/lib/sdr_client/deposit/upload_files.rb
@@ -35,7 +35,7 @@ module SdrClient
           file_name = ::File.basename(path)
           obj[path] = Files::DirectUploadRequest.from_file(path,
                                                            file_name: file_name,
-                                                           content_type: metadata.for(file_name)[:mime_type])
+                                                           content_type: metadata.for(file_name)['mime_type'])
         end
       end
 

--- a/spec/sdr_client/deposit/process_spec.rb
+++ b/spec/sdr_client/deposit/process_spec.rb
@@ -126,12 +126,12 @@ RSpec.describe SdrClient::Deposit::Process do
         let(:files_metadata) do
           {
             'file1.txt' => {
-              md5: 'abc123',
-              sha1: 'def456',
-              mime_type: 'image/tiff',
-              access: 'public',
-              preserve: true,
-              shelve: true
+              'md5' => 'abc123',
+              'sha1' => 'def456',
+              'mime_type' => 'image/tiff',
+              'access' => 'public',
+              'preserve' => true,
+              'shelve' => true
             }
           }
         end

--- a/spec/sdr_client/deposit_spec.rb
+++ b/spec/sdr_client/deposit_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe SdrClient::Deposit do
                           files: ['spec/fixtures/file1.txt'],
                           files_metadata: {
                             'file1.txt' => {
-                              mime_type: 'text/plain',
-                              use: 'transcription'
+                              'mime_type' => 'text/plain',
+                              'use' => 'transcription'
                             }
                           },
                           grouping_strategy: SdrClient::Deposit::MatchingFileGroupingStrategy)


### PR DESCRIPTION

## Why was this change made?

Because it comes from JSON.parse or in google-books FileMetadataBuilder.build (which also makes string keys)

This should fix files coming through with mime-type: application/octet-stream


## Was the documentation (README, wiki) updated?
n/a