### PR TITLE
Add checksum and mime-type generation to the client

### DIFF
--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -26,6 +26,7 @@ module SdrClient
                  logger: Logger.new(STDOUT))
       token = Credentials.read
 
+      augmented_metadata = FileMetadataBuilder.build(files: files, files_metadata: files_metadata)
       metadata = Request.new(label: label,
                              type: type,
                              access: access,
@@ -38,7 +39,7 @@ module SdrClient
                              embargo_release_date: embargo_release_date,
                              embargo_access: embargo_access,
                              viewing_direction: viewing_direction,
-                             files_metadata: files_metadata)
+                             files_metadata: augmented_metadata)
       Process.new(metadata: metadata, url: url, token: token, files: files,
                   grouping_strategy: grouping_strategy, logger: logger).run
     end
@@ -52,6 +53,7 @@ require 'sdr_client/deposit/matching_file_grouping_strategy'
 require 'sdr_client/deposit/files/direct_upload_request'
 require 'sdr_client/deposit/files/direct_upload_response'
 require 'sdr_client/deposit/file'
+require 'sdr_client/deposit/file_metadata_builder'
 require 'sdr_client/deposit/file_set'
 require 'sdr_client/deposit/request'
 require 'sdr_client/deposit/upload_files'

--- a/lib/sdr_client/deposit/file_metadata_builder.rb
+++ b/lib/sdr_client/deposit/file_metadata_builder.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'sdr_client/deposit/file_metadata_builder_operations/mime_type'
+require 'sdr_client/deposit/file_metadata_builder_operations/md5'
+require 'sdr_client/deposit/file_metadata_builder_operations/sha1'
+
+module SdrClient
+  module Deposit
+    # Build basic metadata for files, iterating over a series of operations
+    # The available options are here: https://github.com/sul-dlss/sdr-client/blob/v0.8.1/lib/sdr_client/deposit/file.rb#L8-L10
+    class FileMetadataBuilder
+      OPERATIONS = [
+        FileMetadataBuilderOperations::MimeType,
+        FileMetadataBuilderOperations::MD5,
+        FileMetadataBuilderOperations::SHA1
+      ].freeze
+      private_constant :OPERATIONS
+
+      # @param (see #initialize)
+      # @return (see #build)
+      def self.build(files:, files_metadata:)
+        new(files: files, files_metadata: files_metadata.dup).build
+      end
+
+      # @param [Array<String>] files the list of files for which to generate metadata
+      def initialize(files:, files_metadata:)
+        @files = files
+        @files_metadata = files_metadata
+      end
+
+      # @return [Hash<String, Hash<String, String>>]
+      def build
+        files.each do |file_path|
+          file_key = ::File.basename(file_path)
+          OPERATIONS.each do |operation|
+            result = operation.for(file_path: file_path)
+            next if result.nil?
+
+            files_metadata[file_key] ||= {}
+            files_metadata[file_key][operation::NAME] = result
+          end
+        end
+        files_metadata
+      end
+
+      private
+
+      attr_reader :files, :files_metadata
+    end
+  end
+end

--- a/lib/sdr_client/deposit/file_metadata_builder_operations/md5.rb
+++ b/lib/sdr_client/deposit/file_metadata_builder_operations/md5.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'digest'
+
+module SdrClient
+  module Deposit
+    module FileMetadataBuilderOperations
+      # MD5 for this file.
+      class MD5
+        NAME = 'md5'
+        def self.for(file_path:, **)
+          Digest::MD5.file(file_path).hexdigest
+        end
+      end
+    end
+  end
+end

--- a/lib/sdr_client/deposit/file_metadata_builder_operations/mime_type.rb
+++ b/lib/sdr_client/deposit/file_metadata_builder_operations/mime_type.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'digest'
+
+module SdrClient
+  module Deposit
+    module FileMetadataBuilderOperations
+      # Mime-type for this file.
+      class MimeType
+        NAME = 'mime_type'
+        def self.for(file_path:, **)
+          `file --mime-type -b #{file_path}`.chomp
+        end
+      end
+    end
+  end
+end

--- a/lib/sdr_client/deposit/file_metadata_builder_operations/sha1.rb
+++ b/lib/sdr_client/deposit/file_metadata_builder_operations/sha1.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'digest'
+
+module SdrClient
+  module Deposit
+    module FileMetadataBuilderOperations
+      # SHA1 for this file.
+      class SHA1
+        NAME = 'sha1'
+        def self.for(file_path:, **)
+          Digest::SHA1.file(file_path).hexdigest
+        end
+      end
+    end
+  end
+end

--- a/spec/sdr_client/deposit_spec.rb
+++ b/spec/sdr_client/deposit_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe SdrClient::Deposit do
         filename: 'file1.txt',
         label: 'file1.txt',
         mime_type: 'text/plain',
+        md5: '85a81f69fd85d42c74af78e71ed21ef5',
+        sha1: '4502d57465f953f61c06071d8873f2be20c80824',
         use: 'transcription'
       ).and_call_original
       described_class.run(apo: 'druid:bc123df4567',


### PR DESCRIPTION
## Why was this change made?

So that deposited files have their checksums generated at the source.
Fixes #85 

## Was the documentation (README, wiki) updated?
n/a