### PR TITLE
Adds externalIdentifiers to Request DRO.

### DIFF
--- a/lib/sdr_client.rb
+++ b/lib/sdr_client.rb
@@ -2,6 +2,8 @@
 
 require 'dry/monads'
 require 'faraday'
+require 'active_support'
+require 'active_support/core_ext/object/json'
 
 require 'sdr_client/version'
 require 'sdr_client/deposit'

--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -27,11 +27,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'activesupport'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'cocina-models'
+  spec.add_development_dependency 'cocina-models', '~> 0.28.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.79.0'

--- a/spec/fixtures/file3.txt
+++ b/spec/fixtures/file3.txt
@@ -1,0 +1,1 @@
+This is a fixture file for testing.


### PR DESCRIPTION
## Why was this change made?
SDR API requires external identifiers to match uploaded files with files for item.

## Was the documentation (README, wiki) updated?
No.