### PR TITLE
Extract a connection class

### DIFF
--- a/lib/sdr_client.rb
+++ b/lib/sdr_client.rb
@@ -12,6 +12,7 @@ require 'sdr_client/credentials'
 require 'sdr_client/login'
 require 'sdr_client/login_prompt'
 require 'sdr_client/cli'
+require 'sdr_client/connection'
 
 module SdrClient
   class Error < StandardError; end

--- a/lib/sdr_client/connection.rb
+++ b/lib/sdr_client/connection.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module SdrClient
+  # The connection to the server
+  class Connection
+    def initialize(url:, token: Credentials.read)
+      @url = url
+      @token = token
+    end
+
+    def connection
+      @connection ||= Faraday.new(url: url) do |conn|
+        conn.authorization :Bearer, token
+        conn.adapter :net_http
+      end
+    end
+
+    delegate :put, :post, to: :connection
+
+    private
+
+    attr_reader :url, :token
+  end
+end

--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -25,8 +25,6 @@ module SdrClient
                  files_metadata: {},
                  grouping_strategy: SingleFileGroupingStrategy,
                  logger: Logger.new(STDOUT))
-      token = Credentials.read
-
       augmented_metadata = FileMetadataBuilder.build(files: files, files_metadata: files_metadata)
       metadata = Request.new(label: label,
                              type: type,
@@ -41,7 +39,8 @@ module SdrClient
                              embargo_access: embargo_access,
                              viewing_direction: viewing_direction,
                              files_metadata: augmented_metadata)
-      Process.new(metadata: metadata, url: url, token: token, files: files,
+      connection = Connection.new(url: url)
+      Process.new(metadata: metadata, connection: connection, files: files,
                   grouping_strategy: grouping_strategy, logger: logger).run
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/sdr_client/deposit/process.rb
+++ b/lib/sdr_client/deposit/process.rb
@@ -9,21 +9,17 @@ module SdrClient
       DRO_PATH = '/v1/resources'
       # @param [Request] metadata information about the object
       # @param [Class] grouping_strategy class whose run method groups an array of uploads
-      # @param [String] url the server to send to
-      # @param [String] token the bearer auth token for the server
+      # @param [String] connection the server connection to use
       # @param [Array<String>] files a list of file names to upload
       # @param [Logger] logger the logger to use
-      # rubocop:disable Metrics/ParameterLists
-      def initialize(metadata:, grouping_strategy: SingleFileGroupingStrategy, url:,
-                     token:, files: [], logger: Logger.new(STDOUT))
+      def initialize(metadata:, grouping_strategy: SingleFileGroupingStrategy,
+                     connection:, files: [], logger: Logger.new(STDOUT))
         @files = files
-        @url = url
-        @token = token
+        @connection = connection
         @metadata = metadata
         @logger = logger
         @grouping_strategy = grouping_strategy
       end
-      # rubocop:enable Metrics/ParameterLists
 
       def run
         check_files_exist
@@ -40,7 +36,7 @@ module SdrClient
 
       private
 
-      attr_reader :metadata, :files, :url, :token, :logger, :grouping_strategy
+      attr_reader :metadata, :files, :connection, :logger, :grouping_strategy
 
       def check_files_exist
         logger.info('checking to see if files exist')
@@ -66,13 +62,6 @@ module SdrClient
         raise 'There was an error with your credentials. Perhaps they have expired?' if response.status == 401
 
         raise "unexpected response: #{response.status} #{response.body}"
-      end
-
-      def connection
-        @connection ||= Faraday.new(url: url) do |conn|
-          conn.authorization :Bearer, token
-          conn.adapter :net_http
-        end
       end
 
       def mime_types

--- a/lib/sdr_client/deposit/upload_files.rb
+++ b/lib/sdr_client/deposit/upload_files.rb
@@ -9,7 +9,7 @@ module SdrClient
       BLOB_PATH = '/v1/direct_uploads'
       # @param [Array<String>] files a list of filepaths to upload
       # @param [Logger] logger the logger to use
-      # @param [Faraday::Connection] connection
+      # @param [Connection] connection
       # @param [Hash<String,String] mime_types a map of filenames to mime types
       def initialize(files:, mime_types:, logger:, connection:)
         @files = files

--- a/spec/sdr_client/deposit/process_spec.rb
+++ b/spec/sdr_client/deposit/process_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe SdrClient::Deposit::Process do
                                     files_metadata: files_metadata)
   end
 
+  let(:connection) { SdrClient::Connection.new(url: 'http://example.com:3000', token: 'eyJhbGci') }
   let(:instance) do
     described_class.new(metadata: metadata,
-                        url: 'http://example.com:3000',
-                        token: 'eyJhbGci',
+                        connection: connection,
                         files: files,
                         logger: logger)
   end

--- a/spec/sdr_client/deposit_spec.rb
+++ b/spec/sdr_client/deposit_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe SdrClient::Deposit do
     let(:second_request) { instance_double(SdrClient::Deposit::Request, as_json: {}) }
 
     before do
-      allow(SdrClient::Credentials).to receive(:read).and_return('token')
       allow(SdrClient::Deposit::Request).to receive(:new).and_return(request)
       allow(SdrClient::Deposit::Process).to receive(:new).and_return(process)
     end
@@ -72,8 +71,7 @@ RSpec.describe SdrClient::Deposit do
           .with(grouping_strategy: SdrClient::Deposit::SingleFileGroupingStrategy,
                 files: [],
                 metadata: request,
-                token: 'token',
-                url: 'http://example.com/',
+                connection: SdrClient::Connection,
                 logger: Logger)
 
         expect(process).to have_received(:run)
@@ -95,8 +93,7 @@ RSpec.describe SdrClient::Deposit do
           .with(grouping_strategy: SdrClient::Deposit::MatchingFileGroupingStrategy,
                 files: [],
                 metadata: request,
-                token: 'token',
-                url: 'http://example.com/',
+                connection: SdrClient::Connection,
                 logger: Logger)
 
         expect(process).to have_received(:run)


### PR DESCRIPTION
## Why was this change made?

This can be used for other functions (proxy request) if it's extracted.
Ref https://github.com/sul-dlss/infrastructure-integration-test/issues/28

## Was the documentation (README, wiki) updated?
n/a