### PR TITLE
Use the Connection in the model deposit

### DIFF
--- a/lib/sdr_client/deposit/model_process.rb
+++ b/lib/sdr_client/deposit/model_process.rb
@@ -8,15 +8,12 @@ module SdrClient
     class ModelProcess
       DRO_PATH = '/v1/resources'
       # @param [Cocina::Model::RequestDRO] request_dro for depositing
-      # @param [String] url the server to send to
-      # @param [String] token the bearer auth token for the server
+      # @param [Connection] connection the connection to use
       # @param [Array<String>] files a list of file names to upload
       # @param [Logger] logger the logger to use
-      def initialize(request_dro:, url:,
-                     token:, files: [], logger: Logger.new(STDOUT))
+      def initialize(request_dro:, connection:, files: [], logger: Logger.new(STDOUT))
         @files = files
-        @url = url
-        @token = token
+        @connection = connection
         @request_dro = request_dro
         @logger = logger
       end
@@ -35,7 +32,7 @@ module SdrClient
 
       private
 
-      attr_reader :request_dro, :files, :url, :token, :logger
+      attr_reader :request_dro, :files, :logger, :connection
 
       def check_files_exist
         logger.info('checking to see if files exist')
@@ -75,13 +72,6 @@ module SdrClient
         raise 'There was an error with your credentials. Perhaps they have expired?' if response.status == 401
 
         raise "unexpected response: #{response.status} #{response.body}"
-      end
-
-      def connection
-        @connection ||= Faraday.new(url: url) do |conn|
-          conn.authorization :Bearer, token
-          conn.adapter :net_http
-        end
       end
 
       # Map of filenames to mimetypes

--- a/lib/sdr_client/model_deposit.rb
+++ b/lib/sdr_client/model_deposit.rb
@@ -9,9 +9,8 @@ module SdrClient
                        files: [],
                        url:,
                        logger: Logger.new(STDOUT))
-      token = Credentials.read
-
-      ModelProcess.new(request_dro: request_dro, url: url, token: token, files: files, logger: logger).run
+      connection = Connection.new(url: url)
+      ModelProcess.new(request_dro: request_dro, connection: connection, files: files, logger: logger).run
     end
   end
 end

--- a/spec/sdr_client/deposit/model_process_spec.rb
+++ b/spec/sdr_client/deposit/model_process_spec.rb
@@ -65,10 +65,10 @@ RSpec.describe SdrClient::Deposit::ModelProcess do
     Cocina::Models::RequestDRO.new(submitted_request_dro_hash)
   end
 
+  let(:connection) { SdrClient::Connection.new(url: 'http://example.com:3000', token: 'eyJhbGci') }
   let(:instance) do
     described_class.new(request_dro: request_dro,
-                        url: 'http://example.com:3000',
-                        token: 'eyJhbGci',
+                        connection: connection,
                         files: files)
   end
 

--- a/spec/sdr_client/model_deposit_spec.rb
+++ b/spec/sdr_client/model_deposit_spec.rb
@@ -11,21 +11,22 @@ RSpec.describe SdrClient::Deposit do
     let(:files) { ['spec/fixtures/file1.txt'] }
 
     let(:request_dro) { instance_double(Cocina::Models::RequestDRO) }
-
+    let(:connection) { instance_double(SdrClient::Connection) }
     let(:upload_url) { 'http://localhost:3000/v1/disk/GpscGFUTmxO' }
 
     before do
-      allow(SdrClient::Credentials).to receive(:read).and_return('token')
+      allow(SdrClient::Connection).to receive(:new).and_return(connection)
       allow(SdrClient::Deposit::ModelProcess).to receive(:new).and_return(process)
     end
 
     it 'runs the process' do
       run
+      expect(SdrClient::Connection).to have_received(:new).with(url: upload_url)
+
       expect(SdrClient::Deposit::ModelProcess).to have_received(:new)
         .with(files: files,
               request_dro: request_dro,
-              token: 'token',
-              url: upload_url,
+              connection: connection,
               logger: Logger)
 
       expect(process).to have_received(:run)


### PR DESCRIPTION
## Why was this change made?
So that connection setup is only done one way.


## Was the documentation (README, wiki) updated?
n/a