### PR TITLE
Add a call to get a proxy

### DIFF
--- a/lib/sdr_client/connection.rb
+++ b/lib/sdr_client/connection.rb
@@ -3,6 +3,8 @@
 module SdrClient
   # The connection to the server
   class Connection
+    include Dry::Monads[:result]
+
     def initialize(url:, token: Credentials.read)
       @url = url
       @token = token
@@ -12,6 +14,21 @@ module SdrClient
       @connection ||= Faraday.new(url: url) do |conn|
         conn.authorization :Bearer, token
         conn.adapter :net_http
+      end
+    end
+
+    # This is only available to certain blessed accounts (argo) as it gives the
+    # token that allows you to act as any other user. Thus the caller must authenticate
+    # the user (e.g. using Shibboleth) before calling this method with their email address.
+    # @param [String] the email address of the person to proxy to.
+    # @return [Result] the token for the account
+    def proxy(to)
+      response = connection.post("/v1/auth/proxy?to=#{to}")
+      case response.status
+      when 200
+        Success(response.body)
+      else
+        Failure("Status: #{response.status}\n#{response.body}")
       end
     end
 

--- a/spec/sdr_client/connection_spec.rb
+++ b/spec/sdr_client/connection_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe SdrClient::Connection do
+  subject(:conn) { described_class.new(url: 'http://example.com/', token: 'foobar') }
+
+  describe '#proxy' do
+    subject { conn.proxy('jane@stanford.edu') }
+
+    context 'when the login is successful' do
+      let(:body) do
+        '{"token":"zaa","exp":"2020-04-19"}'
+      end
+
+      before do
+        stub_request(:post, 'http://example.com/v1/auth/proxy?to=jane@stanford.edu')
+          .with(
+            headers: { 'Authorization' => 'Bearer foobar' }
+          )
+          .to_return(status: 200, body: body, headers: {})
+      end
+
+      it 'writes out the token' do
+        expect(subject).to be_success
+        expect(subject.value!).to eq body
+      end
+    end
+
+    context 'when the login is not successful' do
+      before do
+        stub_request(:post, 'http://example.com/v1/auth/proxy?to=jane@stanford.edu')
+          .with(
+            headers: { 'Authorization' => 'Bearer foobar' }
+          )
+          .to_return(status: 400)
+      end
+
+      it 'returns a failure' do
+        expect(subject).to be_failure
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

So that we have the ability to make this call from argo

## Was the documentation (README, wiki) updated?
n/a