### PR TITLE
Tweak to Cocina namespacing.

### DIFF
--- a/lib/sdr_client.rb
+++ b/lib/sdr_client.rb
@@ -5,6 +5,7 @@ require 'faraday'
 require 'active_support'
 require 'active_support/core_ext/object/json'
 require 'active_support/core_ext/hash/indifferent_access'
+require 'cocina/models'
 
 require 'sdr_client/version'
 require 'sdr_client/deposit'


### PR DESCRIPTION
## Why was this change made?
Fix cocina namespacing to avoid:
```
NameError:
       uninitialized constant SdrClient::Deposit::Process::Cocina
```


## Was the documentation (README, wiki) updated?
No.