### PR TITLE
Allow model_run to pass accessioning to ModelProcess

### DIFF
--- a/lib/sdr_client/model_deposit.rb
+++ b/lib/sdr_client/model_deposit.rb
@@ -8,9 +8,14 @@ module SdrClient
     def self.model_run(request_dro:,
                        files: [],
                        url:,
+                       accession:,
                        logger: Logger.new(STDOUT))
       connection = Connection.new(url: url)
-      ModelProcess.new(request_dro: request_dro, connection: connection, files: files, logger: logger).run
+      ModelProcess.new(request_dro: request_dro,
+                       connection: connection,
+                       files: files,
+                       logger: logger,
+                       accession: accession).run
     end
   end
 end

--- a/spec/sdr_client/model_deposit_spec.rb
+++ b/spec/sdr_client/model_deposit_spec.rb
@@ -3,7 +3,8 @@
 RSpec.describe SdrClient::Deposit do
   describe '.run_model' do
     subject(:run) do
-      described_class.model_run(files: files, request_dro: request_dro, url: upload_url)
+      described_class.model_run(files: files, request_dro: request_dro,
+                                url: upload_url, accession: true)
     end
 
     let(:process) { instance_double(SdrClient::Deposit::ModelProcess, run: true) }
@@ -27,7 +28,8 @@ RSpec.describe SdrClient::Deposit do
         .with(files: files,
               request_dro: request_dro,
               connection: connection,
-              logger: Logger)
+              logger: Logger,
+              accession: true)
 
       expect(process).to have_received(:run)
     end


### PR DESCRIPTION
## Why was this change made?
Currently `model_run` doesn't pass accessioning to ModelProcess, causing an argumentError.


## Was the documentation (README, wiki) updated?
no