### PR TITLE
Adds support for deposit returning background job id.

### DIFF
--- a/lib/sdr_client.rb
+++ b/lib/sdr_client.rb
@@ -15,6 +15,7 @@ require 'sdr_client/login'
 require 'sdr_client/login_prompt'
 require 'sdr_client/cli'
 require 'sdr_client/connection'
+require 'sdr_client/background_job_results'
 
 module SdrClient
   class Error < StandardError; end

--- a/lib/sdr_client/background_job_results.rb
+++ b/lib/sdr_client/background_job_results.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module SdrClient
+  # API calls around background job results from dor-services-app
+  module BackgroundJobResults
+    # Get status/result of a background job
+    # @param url [String] url for the service
+    # @param job_id [String] required string representing a job identifier
+    # @return [Hash] result of background job
+    def self.show(url:, job_id:)
+      connection = Connection.new(url: "#{url}/v1/background_job_results/#{job_id}").connection
+      resp = connection.get
+
+      raise "unexpected response: #{response.status} #{response.body}" unless resp.success?
+
+      JSON.parse(resp.body).with_indifferent_access
+    end
+  end
+end

--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -8,6 +8,7 @@ module SdrClient
     BOOK_TYPE = 'http://cocina.sul.stanford.edu/models/book.jsonld'
     # rubocop:disable Metrics/ParameterLists
     # rubocop:disable Metrics/MethodLength
+    # @return [String] job id for the background job result
     def self.run(label: nil,
                  type: BOOK_TYPE,
                  viewing_direction: nil,

--- a/lib/sdr_client/deposit/process.rb
+++ b/lib/sdr_client/deposit/process.rb
@@ -26,6 +26,7 @@ module SdrClient
       # rubocop:enable Metrics/ParameterLists
 
       # rubocop:disable Metrics/AbcSize
+      # @return [String] job id for the background job result
       def run
         check_files_exist
         upload_responses = UploadFiles.new(files: files,

--- a/lib/sdr_client/deposit/upload_resource.rb
+++ b/lib/sdr_client/deposit/upload_resource.rb
@@ -21,14 +21,14 @@ module SdrClient
       end
 
       # @param [Hash<Symbol,String>] the result of the metadata call
-      # @return [Hash<Symbol,String>] the result of the metadata call
+      # @return [String] job id for the background job result
       def run
         response = metadata_request
         unexpected_response(response) unless response.status == 201
 
         logger.info("Response from server: #{response.body}")
 
-        { druid: JSON.parse(response.body)['druid'], background_job: response.headers['Location'] }
+        JSON.parse(response.body)['jobId']
       end
 
       private

--- a/spec/sdr_client/background_job_results_spec.rb
+++ b/spec/sdr_client/background_job_results_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe SdrClient::BackgroundJobResults do
+  describe '.show' do
+    subject { described_class.show(url: 'https://sdr-api-server:3000', job_id: '3') }
+
+    before do
+      stub_request(:get, 'https://sdr-api-server:3000/v1/background_job_results/3')
+        .to_return(status: status_code, body: "{\"status\":\"#{status}\"}", headers: {})
+      allow(SdrClient::Credentials).to receive(:read).and_return('{"token":"zaa","exp":"2020-04-19"}')
+    end
+
+    context 'when ok' do
+      let(:status_code) { 200 }
+      let(:status) { 'completed' }
+      it 'returns the job results' do
+        expect(subject['status']).to eq(status)
+      end
+    end
+
+    context 'when accepted' do
+      let(:status_code) { 202 }
+      let(:status) { 'pending' }
+      it 'returns the job results' do
+        expect(subject['status']).to eq(status)
+      end
+    end
+  end
+end

--- a/spec/sdr_client/deposit/model_process_spec.rb
+++ b/spec/sdr_client/deposit/model_process_spec.rb
@@ -163,13 +163,12 @@ RSpec.describe SdrClient::Deposit::ModelProcess do
               body: submitted_request_dro.to_json,
               headers: { 'Content-Type' => 'application/json' }
             )
-            .to_return(status: 201, body: '{"druid":"druid:bc333df7777"}',
+            .to_return(status: 201, body: '{"jobId":"1"}',
                        headers: { 'Location' => 'http://example.com/background_job/1' })
         end
 
         it 'uploads files' do
-          expect(subject).to eq(background_job: 'http://example.com/background_job/1',
-                                druid: 'druid:bc333df7777')
+          expect(subject).to eq('1')
         end
       end
 

--- a/spec/sdr_client/deposit/process_spec.rb
+++ b/spec/sdr_client/deposit/process_spec.rb
@@ -99,13 +99,12 @@ RSpec.describe SdrClient::Deposit::Process do
               body: '{"type":"http://cocina.sul.stanford.edu/models/book.jsonld","label":"This is my object","version":1,"access":{"access":"world","download":"none"},"administrative":{"hasAdminPolicy":"druid:bc123df4567"},"identification":{"sourceId":"googlebooks:12345"},"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld","label":"Page 1","version":1,"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld","label":"file1.txt","filename":"file1.txt","version":1,"externalIdentifier":"BaHBLZz09Iiw","hasMessageDigests":[],"access":{"access":"world","download":"none"},"administrative":{"sdrPreserve":true,"shelve":true}}]}},{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld","label":"Page 2","version":1,"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld","label":"file2.txt","filename":"file2.txt","version":1,"externalIdentifier":"dz09IiwiZXhwIjpudWxsLC","hasMessageDigests":[],"access":{"access":"world","download":"none"},"administrative":{"sdrPreserve":true,"shelve":true}}]}}],"isMemberOf":"druid:gh123df4567"}}',
               headers: { 'Content-Type' => 'application/json' }
             )
-            .to_return(status: 201, body: '{"druid":"druid:bc333df7777"}',
+            .to_return(status: 201, body: '{"jobId":"1"}',
                        headers: { 'Location' => 'http://example.com/background_job/1' })
         end
 
         it 'uploads files' do
-          expect(subject).to eq(background_job: 'http://example.com/background_job/1',
-                                druid: 'druid:bc333df7777')
+          expect(subject).to eq('1')
         end
       end
 
@@ -179,13 +178,12 @@ RSpec.describe SdrClient::Deposit::Process do
               body: '{"type":"http://cocina.sul.stanford.edu/models/book.jsonld","label":"This is my object","version":1,"access":{"access":"world","download":"none"},"administrative":{"hasAdminPolicy":"druid:bc123df4567"},"identification":{"sourceId":"googlebooks:12345"},"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld","label":"Page 1","version":1,"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld","label":"file1.txt","filename":"file1.txt","version":1,"hasMimeType":"image/tiff","externalIdentifier":"BaHBLZz09Iiw","hasMessageDigests":[{"type":"md5","digest":"abc123"},{"type":"sha1","digest":"def456"}],"access":{"access":"dark","download":"none"},"administrative":{"sdrPreserve":false,"shelve":false}}]}},{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld","label":"Page 2","version":1,"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld","label":"file2.txt","filename":"file2.txt","version":1,"externalIdentifier":"dz09IiwiZXhwIjpudWxsLC","hasMessageDigests":[],"access":{"access":"world","download":"none"},"administrative":{"sdrPreserve":true,"shelve":true}}]}}],"isMemberOf":"druid:gh123df4567"}}',
               headers: { 'Content-Type' => 'application/json' }
             )
-            .to_return(status: 201, body: '{"druid":"druid:bc333df7777"}',
+            .to_return(status: 201, body: '{"jobId":"1"}',
                        headers: { 'Location' => 'http://example.com/background_job/1' })
         end
 
         it 'uploads files' do
-          expect(subject).to eq(background_job: 'http://example.com/background_job/1',
-                                druid: 'druid:bc333df7777')
+          expect(subject).to eq('1')
         end
       end
 


### PR DESCRIPTION
## Why was this change made?
To support the ingest job working entirely async. This will require being able to receive and check a background job result.


## How was this change tested?
In stage.


## Which documentation and/or configurations were updated?
Yes.


