### PR TITLE
Fix when error raised getting background job result.

### DIFF
--- a/lib/sdr_client/background_job_results.rb
+++ b/lib/sdr_client/background_job_results.rb
@@ -13,7 +13,7 @@ module SdrClient
       connection = Connection.new(url: "#{url}/v1/background_job_results/#{job_id}").connection
       resp = connection.get
 
-      raise "unexpected response: #{response.status} #{response.body}" unless resp.success?
+      raise "unexpected response: #{resp.status} #{resp.body}" unless resp.success?
 
       JSON.parse(resp.body).with_indifferent_access
     end

--- a/spec/sdr_client/background_job_results_spec.rb
+++ b/spec/sdr_client/background_job_results_spec.rb
@@ -25,5 +25,13 @@ RSpec.describe SdrClient::BackgroundJobResults do
         expect(subject['status']).to eq(status)
       end
     end
+
+    context 'when error' do
+      let(:status_code) { 500 }
+      let(:status) { 'error' }
+      it 'raises' do
+        expect { subject }.to raise_error(/unexpected response: 500/)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?
Raising background job result errors referenced incorrect variables.


## How was this change tested?
Unit test.


## Which documentation and/or configurations were updated?
NA


