### PR TITLE
Add the default endpoint url

### DIFF
--- a/exe/sdr
+++ b/exe/sdr
@@ -106,6 +106,7 @@ end
 subcommands[command].order!
 
 options[:files] = ARGV unless ARGV.empty?
+options[:url] ||= 'https://sdr-api-prod.stanford.edu'
 
 begin
   SdrClient::CLI.start(command, options)


### PR DESCRIPTION
## Why was this change made?

So that users don't need to type in the url each time they use this.

## How was this change tested?

Locally


## Which documentation and/or configurations were updated?
n/a


