### PR TITLE
Properly unwrap the failure monad

### DIFF
--- a/lib/sdr_client/cli.rb
+++ b/lib/sdr_client/cli.rb
@@ -42,7 +42,7 @@ module SdrClient
         SdrClient::Deposit.run(accession: false, **options)
       when 'login'
         status = SdrClient::Login.run(options)
-        puts status.value if status.failure?
+        puts status.failure if status.failure?
       else
         raise "Unknown command #{command}"
       end


### PR DESCRIPTION
## Why was this change made?

`#value` is not a method on the Failure monad

## How was this change tested?

tested locally.

## Which documentation and/or configurations were updated?
n/a


