### PR TITLE
Adds flush when writing credentials file.

### DIFF
--- a/lib/sdr_client/credentials.rb
+++ b/lib/sdr_client/credentials.rb
@@ -12,6 +12,7 @@ module SdrClient
       File.open(credentials_file, 'w', 0o600) do |file|
         file.flock(File::LOCK_EX)
         file.write(json.fetch('token'))
+        file.flush
       end
     end
 


### PR DESCRIPTION
refs https://github.com/sul-dlss/google-books/issues/578

## Why was this change made?
Try to avoid problems reading credentials.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
No.


