### PR TITLE
Switch reading credentials file to exclusive lock.

### DIFF
--- a/lib/sdr_client/credentials.rb
+++ b/lib/sdr_client/credentials.rb
@@ -21,7 +21,7 @@ module SdrClient
 
       creds = nil
       File.open(credentials_file, 'r') do |file|
-        file.flock(File::LOCK_SH)
+        file.flock(File::LOCK_EX)
         creds = file.readlines(chomp: true).first
       end
       raise NoCredentialsError if creds.nil?


### PR DESCRIPTION
refs https://github.com/sul-dlss/google-books/issues/578

## Why was this change made?
To prevent multiple processes from stepping on each other when reading/writing credentials.


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
NA


