### PR TITLE
Switch to atomic_write for writing credentials.

### DIFF
--- a/lib/sdr_client.rb
+++ b/lib/sdr_client.rb
@@ -5,6 +5,7 @@ require 'faraday'
 require 'active_support'
 require 'active_support/core_ext/object/json'
 require 'active_support/core_ext/hash/indifferent_access'
+require 'active_support/core_ext/file/atomic'
 require 'cocina/models'
 
 require 'sdr_client/version'


### PR DESCRIPTION
refs https://github.com/sul-dlss/google-books/issues/575

## Why was this change made?
Credentials read/write keep clobbering each other.


## How was this change tested?
Will be tested in stage.


## Which documentation and/or configurations were updated?
No.


