### PR TITLE
Upgrade cocina to 0.34.1

### DIFF
--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'cocina-models', '~> 0.33.0'
+  spec.add_dependency 'cocina-models', '~> 0.34.1'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'
 


### PR DESCRIPTION
## Why was this change made?

To use the latest cocina-models client which requires an APO.

## How was this change tested?
Test suite


## Which documentation and/or configurations were updated?

n/a

