### PR TITLE
Upgrade cocina-models to 0.40.1

### DIFF
--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'cocina-models', '~> 0.39.0'
+  spec.add_dependency 'cocina-models', '~> 0.40.1'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'
 


### PR DESCRIPTION
## Why was this change made?
Fixes descriptive metadata map for items with parallel (translated) titles.


## How was this change tested?



## Which documentation and/or configurations were updated?



