### PR TITLE
use cocina-models version 0.44.0

### DIFF
--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'cocina-models', '~> 0.43.0'
+  spec.add_dependency 'cocina-models', '~> 0.44.0'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'
 


### PR DESCRIPTION
## Why was this change made?

For mapping ticket sul-dlss/dor-services-app#1499, we needed a tiny additive change in cocina-models 0.44.0. This change is in sdr-api with PR sul-dlss/sdr-api/pull/255

## How was this change tested?



## Which documentation and/or configurations were updated?



