### PR TITLE
add service_name field to DirectUploadResponse

### DIFF
--- a/lib/sdr_client/deposit/files/direct_upload_response.rb
+++ b/lib/sdr_client/deposit/files/direct_upload_response.rb
@@ -5,7 +5,7 @@ module SdrClient
     module Files
       DirectUploadResponse = Struct.new(:id, :key, :checksum, :byte_size, :content_type,
                                         :filename, :metadata, :created_at, :direct_upload,
-                                        :signed_id, keyword_init: true)
+                                        :signed_id, :service_name, keyword_init: true)
     end
   end
 end

--- a/spec/sdr_client/deposit/model_process_spec.rb
+++ b/spec/sdr_client/deposit/model_process_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe SdrClient::Deposit::ModelProcess do
               'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
               'Authorization' => 'Bearer eyJhbGci',
               'Content-Type' => 'application/json',
-              'User-Agent' => 'Faraday v1.1.0'
+              'User-Agent' => /Faraday v1/
             }
           )
           .to_return(status: 201, body: '{"jobId":"1"}',


### PR DESCRIPTION
## Why was this change made?

the [upgrade to rails 6.1](https://github.com/sul-dlss/sdr-api/pull/259) in sdr-api added a new column to the [`active_storage_blobs`](https://github.com/sul-dlss/sdr-api/pull/259/files#diff-1dd5a8f580b9615769ddc19a64a98f455d9d20eb149c443f41d9d3c797d39b12R62-R72) table.  sdr-api is sending this back in the response for file uploads, and since the field wasn't declared in the `DirectUploadResponse` `Struct`, it was causing an error when attempting to instantiate `DirectUplaodResponse` from the actual updated sdr-api responses.

## How was this change tested?

unit tests, integration tests (using this branch of sdr-client in the integration test suite, as well as a stage deployment of H2 which uses this branch of sdr-client).

see also:
https://github.com/sul-dlss/happy-heron/pull/801
https://github.com/sul-dlss/infrastructure-integration-test/pull/189

## Which documentation and/or configurations were updated?

n/a