### PR TITLE
SdrClient::Deposit::CreateResource: always pass along explicit value for accession flag

### DIFF
--- a/lib/sdr_client/deposit/create_resource.rb
+++ b/lib/sdr_client/deposit/create_resource.rb
@@ -47,9 +47,7 @@ module SdrClient
       end
 
       def path
-        path = DRO_PATH
-        path += '?accession=true' if accession?
-        path
+        "#{DRO_PATH}?accession=#{accession?}"
       end
     end
   end

--- a/spec/sdr_client/deposit/process_spec.rb
+++ b/spec/sdr_client/deposit/process_spec.rb
@@ -12,12 +12,13 @@ RSpec.describe SdrClient::Deposit::Process do
   end
 
   let(:connection) { SdrClient::Connection.new(url: 'http://example.com:3000', token: 'eyJhbGci') }
+  let(:accession) { false }
   let(:instance) do
     described_class.new(metadata: metadata,
                         connection: connection,
                         files: files,
                         logger: logger,
-                        accession: false)
+                        accession: accession)
   end
 
   let(:logger) { instance_double(Logger, info: nil, debug: nil) }
@@ -94,7 +95,7 @@ RSpec.describe SdrClient::Deposit::Process do
             )
             .to_return(status: 204)
 
-          stub_request(:post, 'http://example.com:3000/v1/resources')
+          stub_request(:post, "http://example.com:3000/v1/resources?accession=#{accession}")
             .with(
               body: '{"type":"http://cocina.sul.stanford.edu/models/book.jsonld","label":"This is my object","version":1,"access":{"access":"world","download":"none"},"administrative":{"hasAdminPolicy":"druid:bc123df4567"},"identification":{"sourceId":"googlebooks:12345"},"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld","label":"Page 1","version":1,"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld","label":"file1.txt","filename":"file1.txt","version":1,"externalIdentifier":"BaHBLZz09Iiw","hasMessageDigests":[],"access":{"access":"world","download":"none"},"administrative":{"sdrPreserve":true,"shelve":true}}]}},{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld","label":"Page 2","version":1,"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld","label":"file2.txt","filename":"file2.txt","version":1,"externalIdentifier":"dz09IiwiZXhwIjpudWxsLC","hasMessageDigests":[],"access":{"access":"world","download":"none"},"administrative":{"sdrPreserve":true,"shelve":true}}]}}],"isMemberOf":["druid:gh123df4567"]}}',
               headers: { 'Content-Type' => 'application/json' }
@@ -105,6 +106,14 @@ RSpec.describe SdrClient::Deposit::Process do
 
         it 'uploads files' do
           expect(subject).to eq('1')
+        end
+
+        context 'when accession is true' do
+          let(:accession) { true }
+
+          it 'uploads files' do
+            expect(subject).to eq('1')
+          end
         end
       end
 
@@ -173,7 +182,7 @@ RSpec.describe SdrClient::Deposit::Process do
             )
             .to_return(status: 204)
 
-          stub_request(:post, 'http://example.com:3000/v1/resources')
+          stub_request(:post, "http://example.com:3000/v1/resources?accession=#{accession}")
             .with(
               body: '{"type":"http://cocina.sul.stanford.edu/models/book.jsonld","label":"This is my object","version":1,"access":{"access":"world","download":"none"},"administrative":{"hasAdminPolicy":"druid:bc123df4567"},"identification":{"sourceId":"googlebooks:12345"},"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld","label":"Page 1","version":1,"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld","label":"file1.txt","filename":"file1.txt","version":1,"hasMimeType":"image/tiff","externalIdentifier":"BaHBLZz09Iiw","hasMessageDigests":[{"type":"md5","digest":"abc123"},{"type":"sha1","digest":"def456"}],"access":{"access":"dark","download":"none"},"administrative":{"sdrPreserve":false,"shelve":false}}]}},{"type":"http://cocina.sul.stanford.edu/models/fileset.jsonld","label":"Page 2","version":1,"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld","label":"file2.txt","filename":"file2.txt","version":1,"externalIdentifier":"dz09IiwiZXhwIjpudWxsLC","hasMessageDigests":[],"access":{"access":"world","download":"none"},"administrative":{"sdrPreserve":true,"shelve":true}}]}}],"isMemberOf":["druid:gh123df4567"]}}',
               headers: { 'Content-Type' => 'application/json' }
@@ -239,7 +248,7 @@ RSpec.describe SdrClient::Deposit::Process do
             )
             .to_return(status: 204)
 
-          stub_request(:post, 'http://example.com:3000/v1/resources')
+          stub_request(:post, "http://example.com:3000/v1/resources?accession=#{accession}")
             .to_return(status: 400, body: '{"id":"bad_request",' \
               '"message":"#/components/schemas/DROStructural missing required parameters: isMemberOf"}')
         end
@@ -301,7 +310,7 @@ RSpec.describe SdrClient::Deposit::Process do
             )
             .to_return(status: 204)
 
-          stub_request(:post, 'http://example.com:3000/v1/resources')
+          stub_request(:post, "http://example.com:3000/v1/resources?accession=#{accession}")
             .to_return(status: 401)
         end
 


### PR DESCRIPTION
## Why was this change made?

If sdr-api does not get an explicit parameter value for the `accession` flag on the `/resources` route, it defaults to `true` (because `IngestJob`, invoked by the sdr-api controller method, defaults `accession` to `true` when it's unspecified).

Previously, sdr-client would only send along a value if the caller specified `true` for the `accession` flag.  Hence, when the caller specified `false`, the value was omitted from the request, defaulting to `accession=true` behavior, and effectively never allowing sdr-client users to specify `accession=false`.

Modified an existing spec that already passed `false` for the `accession` flag to test that the path was built with an explicit `accession=false`.  Also parameterized it so that `accession=true` could be tested for one case.

## How was this change tested?

unit tests.  can also deploy to stage or QA and run infra integration test suite.

## Which documentation and/or configurations were updated?

n/a

