### PR TITLE
Bump cocina-models dependency to 0.58.0

### DIFF
--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'cocina-models', '~> 0.57.0'
+  spec.add_dependency 'cocina-models', '~> 0.58.0'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'
 

--- a/spec/sdr_client/deposit/process_spec.rb
+++ b/spec/sdr_client/deposit/process_spec.rb
@@ -106,12 +106,12 @@ RSpec.describe SdrClient::Deposit::Process do
               '{"type":"http://cocina.sul.stanford.edu/models/resources/file.jsonld","label":"Page 1","version":1,' \
               '"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \
               '"label":"file1.txt","filename":"file1.txt","version":1,"externalIdentifier":"BaHBLZz09Iiw",' \
-              '"hasMessageDigests":[],"access":{"access":"world","download":"none"},' \
+              '"hasMessageDigests":[],"access":{"access":"world"},' \
               '"administrative":{"publish":true,"sdrPreserve":true,"shelve":true}}]}},' \
               '{"type":"http://cocina.sul.stanford.edu/models/resources/file.jsonld","label":"Page 2","version":1,' \
               '"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \
               '"label":"file2.txt","filename":"file2.txt","version":1,"externalIdentifier":"dz09IiwiZXhwIjpudWxsLC",' \
-              '"hasMessageDigests":[],"access":{"access":"world","download":"none"},' \
+              '"hasMessageDigests":[],"access":{"access":"world"},' \
               '"administrative":{"publish":true,"sdrPreserve":true,"shelve":true}}]}}],' \
               '"isMemberOf":["druid:gh123df4567"]}}',
               headers: { 'Content-Type' => 'application/json' }
@@ -212,14 +212,14 @@ RSpec.describe SdrClient::Deposit::Process do
               '"label":"file1.txt","filename":"file1.txt","version":1,"hasMimeType":"image/tiff",' \
               '"externalIdentifier":"BaHBLZz09Iiw",' \
               '"hasMessageDigests":[{"type":"md5","digest":"abc123"},{"type":"sha1","digest":"def456"}],' \
-              '"access":{"access":"dark","download":"none"},' \
+              '"access":{"access":"dark"},' \
               '"administrative":{"publish":false,"sdrPreserve":false,"shelve":false}}]}},' \
               '{"type":"http://cocina.sul.stanford.edu/models/resources/file.jsonld",' \
               '"label":"Page 2","version":1,' \
               '"structural":{"contains":[{"type":"http://cocina.sul.stanford.edu/models/file.jsonld",' \
               '"label":"file2.txt","filename":"file2.txt","version":1,' \
               '"externalIdentifier":"dz09IiwiZXhwIjpudWxsLC","hasMessageDigests":[],' \
-              '"access":{"access":"world","download":"none"},' \
+              '"access":{"access":"world"},' \
               '"administrative":{"publish":true,"sdrPreserve":true,"shelve":true}}]}}],' \
               '"isMemberOf":["druid:gh123df4567"]}}',
               headers: { 'Content-Type' => 'application/json' }


### PR DESCRIPTION
## Why was this change made?

So that we can set non-required values from something that exists to nil.

## How was this change tested?



## Which documentation and/or configurations were updated?



