### PR TITLE
Send cocina models version when making a request

### DIFF
--- a/lib/sdr_client/deposit/create_resource.rb
+++ b/lib/sdr_client/deposit/create_resource.rb
@@ -39,7 +39,9 @@ module SdrClient
         json = metadata.to_json
         logger.debug("Starting upload metadata: #{json}")
 
-        connection.post(path, json, 'Content-Type' => 'application/json')
+        connection.post(path, json,
+                        'Content-Type' => 'application/json',
+                        'X-Cocina-Models-Version' => Cocina::Models::VERSION)
       end
 
       def accession?

--- a/lib/sdr_client/deposit/update_resource.rb
+++ b/lib/sdr_client/deposit/update_resource.rb
@@ -37,7 +37,9 @@ module SdrClient
         json = metadata.to_json
         logger.debug("Starting upload metadata: #{json}")
 
-        connection.put(path(metadata), json, 'Content-Type' => 'application/json')
+        connection.put(path(metadata), json,
+                       'Content-Type' => 'application/json',
+                       'X-Cocina-Models-Version' => Cocina::Models::VERSION)
       end
 
       def path(metadata)


### PR DESCRIPTION


## Why was this change made?
This allows the server to say "sorry, your version is too old"


## How was this change tested?



## Which documentation and/or configurations were updated?



