### PR TITLE
Prevent dark files from being shelved

### DIFF
--- a/lib/sdr_client/deposit/file.rb
+++ b/lib/sdr_client/deposit/file.rb
@@ -15,7 +15,7 @@ module SdrClient
         @access = access
         @download = download
         @preserve = preserve
-        @shelve = shelve
+        @shelve = access == 'dark' ? false : shelve
         @publish = publish
         @mime_type = mime_type
         @md5 = md5

--- a/lib/sdr_client/deposit/file_set.rb
+++ b/lib/sdr_client/deposit/file_set.rb
@@ -5,7 +5,7 @@ module SdrClient
     # This represents the FileSet metadata that we send to the server for doing a deposit
     class FileSet
       # @param [Array] uploads
-      # @param [Hash<String,Hash<String,String>>] the file level metadata
+      # @param [Hash<String,Hash<String,String>>] uploads_metadata the file level metadata
       # @param [Array] files
       # @param [String] label
       def initialize(uploads: [], uploads_metadata: {}, files: [], label:)

--- a/spec/sdr_client/deposit/request_spec.rb
+++ b/spec/sdr_client/deposit/request_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe SdrClient::Deposit::Request do
                       label: 'file2.png',
                       filename: 'file2.png',
                       access: { access: 'dark', download: 'none' },
-                      administrative: { publish: true, sdrPreserve: true, shelve: true },
+                      administrative: { publish: true, sdrPreserve: true, shelve: false },
                       externalIdentifier: 'bar-file2',
                       version: 1,
                       hasMessageDigests: []


### PR DESCRIPTION

## Why was this change made?
Becuase this leads to an error from dor-services-app via the Cocina::ValidateDarkService
https://github.com/sul-dlss/dor-services-app/blob/2ac9d78e999eb9a738a8c887d0b6e2f0ce726730/app/validators/cocina/validate_dark_service.rb#L17

The default instructions on the README result in this error.


## How was this change tested?



## Which documentation and/or configurations were updated?



