### PR TITLE
Update cocina-models to 0.62

### DIFF
--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'cocina-models', '~> 0.61.0'
+  spec.add_dependency 'cocina-models', '~> 0.62.0'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'
 


### PR DESCRIPTION
## Why was this change made?

So that purl can be normalized to https

## How was this change tested?



## Which documentation and/or configurations were updated?



