### PR TITLE
connection: use new faraday syntax to avoid warnings

### DIFF
--- a/lib/sdr_client/connection.rb
+++ b/lib/sdr_client/connection.rb
@@ -14,7 +14,7 @@ module SdrClient
 
     def connection
       @connection ||= Faraday.new(url: url, request: request_options) do |conn|
-        conn.authorization :Bearer, token
+        conn.request :authorization, :Bearer, token
         conn.adapter :net_http
       end
     end


### PR DESCRIPTION
## Why was this change made?

To avoid this:

```
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```

## How was this change tested?

analogous change made in infra-int tests

## Which documentation and/or configurations were updated?



