### PR TITLE
Revert most of #170

### DIFF
--- a/lib/sdr_client.rb
+++ b/lib/sdr_client.rb
@@ -2,7 +2,6 @@
 
 require 'dry/monads'
 require 'faraday'
-require 'faraday/net_http'
 require 'active_support'
 require 'active_support/core_ext/object/json'
 require 'active_support/core_ext/hash/indifferent_access'

--- a/lib/sdr_client/login.rb
+++ b/lib/sdr_client/login.rb
@@ -9,7 +9,6 @@ module SdrClient
     # @return [Result] the status of the call
     def self.run(url:, login_service: LoginPrompt, credential_store: Credentials)
       request_json = JSON.generate(login_service.run)
-      Faraday.default_adapter = :net_http
       response = Faraday.post(url + LOGIN_PATH, request_json, 'Content-Type' => 'application/json')
       case response.status
       when 200

--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -30,8 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport'
   spec.add_dependency 'cocina-models', '~> 0.62.0'
   spec.add_dependency 'dry-monads'
-  spec.add_dependency 'faraday', '~> 2.0'
-  spec.add_dependency 'faraday-net_http'
+  spec.add_dependency 'faraday', '>= 0.16'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION


## Why was this change made?
Faraday 2.0.1 was released which provides the default net_http adapter, so this gem can remain more flexible


## How was this change tested?



## Which documentation and/or configurations were updated?



