### PR TITLE
Increase read_timeout from 3 to 6 minutes

### DIFF
--- a/lib/sdr_client/connection.rb
+++ b/lib/sdr_client/connection.rb
@@ -6,7 +6,7 @@ module SdrClient
     include Dry::Monads[:result]
 
     # @param [Integer] read_timeout the value in seconds to set the read timeout
-    def initialize(url:, token: Credentials.read, read_timeout: 180)
+    def initialize(url:, token: Credentials.read, read_timeout: 360)
       @url = url
       @token = token
       @request_options = { read_timeout: read_timeout }


### PR DESCRIPTION
## Why was this change made?

We are seeing a timeout when depositing an 8+gb object

https://app.honeybadger.io/projects/77112/faults/81085562

https://github.com/sul-dlss/happy-heron/issues/2128

## How was this change tested?



## Which documentation and/or configurations were updated?



