### PR TITLE
Use type strategy with deposit

### DIFF
--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -28,6 +28,7 @@ module SdrClient
                  files_metadata: {},
                  accession: false,
                  grouping_strategy: SingleFileGroupingStrategy,
+                 file_set_type_strategy: FileTypeFileSetStrategy,
                  logger: Logger.new($stdout))
       augmented_metadata = FileMetadataBuilder.build(files: files, files_metadata: files_metadata)
       metadata = Request.new(label: label,
@@ -48,6 +49,7 @@ module SdrClient
       connection = Connection.new(url: url)
       Process.new(metadata: metadata, connection: connection, files: files,
                   grouping_strategy: grouping_strategy,
+                  file_set_type_strategy: file_set_type_strategy,
                   accession: accession,
                   logger: logger).run
     end

--- a/lib/sdr_client/deposit/metadata_builder.rb
+++ b/lib/sdr_client/deposit/metadata_builder.rb
@@ -10,6 +10,7 @@ module SdrClient
       # @param [Class] grouping_strategy class whose run method groups an array of uploads
       # Additional metadata includes access, preserve, shelve, publish, md5, sha1
       # @param [Logger] logger the logger to use
+      # @param [Class] file_set_type_strategy class whose run method determines file_set type
       def initialize(metadata:, grouping_strategy:, logger:, file_set_type_strategy: FileTypeFileSetStrategy)
         @metadata = metadata
         @logger = logger

--- a/lib/sdr_client/deposit/process.rb
+++ b/lib/sdr_client/deposit/process.rb
@@ -10,6 +10,7 @@ module SdrClient
       # @param [String] connection the server connection to use
       # @param [Boolean] accession should the accessionWF be started
       # @param [Class] grouping_strategy class whose run method groups an array of uploads
+      # @param [Class] file_set_type_strategy class whose run method determines file_set type
       # @param [Array<String>] files a list of file names to upload
       # @param [Boolean] assign_doi should a DOI be assigned to this item
       # @param [Logger] logger the logger to use
@@ -19,6 +20,7 @@ module SdrClient
                      connection:,
                      accession:,
                      grouping_strategy: SingleFileGroupingStrategy,
+                     file_set_type_strategy: FileTypeFileSetStrategy,
                      files: [],
                      assign_doi: false,
                      logger: Logger.new($stdout))
@@ -27,6 +29,7 @@ module SdrClient
         @metadata = metadata
         @logger = logger
         @grouping_strategy = grouping_strategy
+        @file_set_type_strategy = file_set_type_strategy
         @accession = accession
         @assign_doi = assign_doi
       end
@@ -43,6 +46,7 @@ module SdrClient
                                               connection: connection)
         metadata_builder = MetadataBuilder.new(metadata: metadata,
                                                grouping_strategy: grouping_strategy,
+                                               file_set_type_strategy: file_set_type_strategy,
                                                logger: logger)
         request = metadata_builder.with_uploads(upload_responses)
         model = Cocina::Models.build_request(request.as_json.with_indifferent_access)
@@ -56,7 +60,7 @@ module SdrClient
 
       private
 
-      attr_reader :metadata, :files, :connection, :logger, :grouping_strategy
+      attr_reader :metadata, :files, :connection, :logger, :grouping_strategy, :file_set_type_strategy
 
       def check_files_exist
         logger.info('checking to see if files exist')

--- a/spec/sdr_client/deposit_spec.rb
+++ b/spec/sdr_client/deposit_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe SdrClient::Deposit do
                 metadata: request,
                 connection: SdrClient::Connection,
                 logger: Logger,
+                file_set_type_strategy: SdrClient::Deposit::FileTypeFileSetStrategy,
                 accession: false)
 
         expect(process).to have_received(:run)
@@ -99,6 +100,7 @@ RSpec.describe SdrClient::Deposit do
                 metadata: request,
                 connection: SdrClient::Connection,
                 logger: Logger,
+                file_set_type_strategy: SdrClient::Deposit::FileTypeFileSetStrategy,
                 accession: false)
 
         expect(process).to have_received(:run)

--- a/spec/sdr_client/deposit_spec.rb
+++ b/spec/sdr_client/deposit_spec.rb
@@ -107,6 +107,53 @@ RSpec.describe SdrClient::Deposit do
       end
     end
 
+    context 'without a file_set_type_strategy' do
+      subject(:run) do
+        described_class.run(apo: 'druid:bc123df4567',
+                            collection: 'druid:gh123df4567',
+                            source_id: 'googlebooks:12345',
+                            url: 'http://example.com/')
+      end
+
+      it 'runs the process with the default file_set_type_strategy' do
+        run
+        expect(SdrClient::Deposit::Process).to have_received(:new)
+          .with(files: [],
+                metadata: request,
+                connection: SdrClient::Connection,
+                logger: Logger,
+                grouping_strategy: SdrClient::Deposit::SingleFileGroupingStrategy,
+                file_set_type_strategy: SdrClient::Deposit::FileTypeFileSetStrategy,
+                accession: false)
+
+        expect(process).to have_received(:run)
+      end
+    end
+
+    context 'with a file_set_type_strategy' do
+      subject(:run) do
+        described_class.run(apo: 'druid:bc123df4567',
+                            collection: 'druid:gh123df4567',
+                            source_id: 'googlebooks:12345',
+                            url: 'http://example.com/',
+                            file_set_type_strategy: SdrClient::Deposit::ImageFileSetStrategy)
+      end
+
+      it 'runs the process with the specified file_set_type_strategy' do
+        run
+        expect(SdrClient::Deposit::Process).to have_received(:new)
+          .with(files: [],
+                metadata: request,
+                connection: SdrClient::Connection,
+                logger: Logger,
+                grouping_strategy: SdrClient::Deposit::SingleFileGroupingStrategy,
+                file_set_type_strategy: SdrClient::Deposit::ImageFileSetStrategy,
+                accession: false)
+
+        expect(process).to have_received(:run)
+      end
+    end
+
     context 'with a viewing_direction' do
       subject(:run) do
         described_class.run(apo: 'druid:bc123df4567',


### PR DESCRIPTION
## Why was this change made?
Follow on to #178 to be able to use sdr-client to deposit files that are images. 
 
## How was this change tested?

Running specs, adding a test.

## Which documentation and/or configurations were updated?



