### PR TITLE
Bump connection timeouts higher

### DIFF
--- a/lib/sdr_client/connection.rb
+++ b/lib/sdr_client/connection.rb
@@ -6,10 +6,10 @@ module SdrClient
     include Dry::Monads[:result]
 
     # @param [Integer] read_timeout the value in seconds to set the read timeout
-    def initialize(url:, token: Credentials.read, read_timeout: 360)
+    def initialize(url:, token: Credentials.read, read_timeout: default_timeout, timeout: default_timeout)
       @url = url
       @token = token
-      @request_options = { read_timeout: read_timeout }
+      @request_options = { read_timeout: read_timeout, timeout: timeout }
     end
 
     def connection
@@ -39,5 +39,11 @@ module SdrClient
     private
 
     attr_reader :url, :token, :request_options
+
+    # NOTE: This is the number of seconds it roughly takes for H2 to
+    #       successfully shunt ~10GB files over to SDR API
+    def default_timeout
+      900
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Connects to sul-dlss/happy-heron#2200

We need to bump the timeouts to be able to upload multiple large files serially. I gradually bumped this number up from 360 to 900 until I found values that worked for multiple ~10GB files. 900 turned out to be the magic number.


## How was this change tested? 🤨

CI and tested in prod
