### PR TITLE
Add ability to pipe Cocina to the SDR CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,12 @@ sdr update druid:bb408qn5061 --url https://sdr-api-server:3000 --license "https:
 # Change access controls
 sdr update druid:bb408qn5061 --url https://sdr-api-server:3000 --view "location-based" --download "none" --location "music" --cdl false
 
-# Change Cocina wholesale from a file (note that you can use this flag with the
-# others above, and the flags above will replace what's supplied in the cocina file)
+# Change Cocina wholesale, either:
+# 1. From a file
 sdr update druid:bb408qn5061 --url https://sdr-api-server:3000 --cocina-file bb408qn5061.json
+# 2. Piped in on the command-line
+sdr get druid:b408qn5061 --url https://sdr-api-server:3000 | exe/remove_w3cdtf_encoding_from_event_dates | sdr update druid:bb408qn5061 --url https://sdr-api-server:3000 --cocina-pipe
+# Note that you can use either of these flags with the others above, and the flags above will replace what's supplied in the cocina file or pipe
 ```
 
 ## Testing

--- a/exe/remove_w3cdtf_encoding_from_event_dates
+++ b/exe/remove_w3cdtf_encoding_from_event_dates
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift 'lib'
+
+require 'sdr_client'
+
+output = JSON.parse($stdin.read).tap do |hash|
+  hash.dig('description', 'event').each do |event|
+    event['date'].each do |event_date|
+      event_date.delete('encoding') if event_date.dig('encoding', 'code') == 'w3cdtf'
+    end
+  end
+end.to_json
+
+puts output

--- a/lib/sdr_client/cli.rb
+++ b/lib/sdr_client/cli.rb
@@ -31,7 +31,7 @@ module SdrClient
 
     desc 'get DRUID', 'Retrieve an object from the SDR'
     def get(druid)
-      say SdrClient::Find.run(druid, url: options[:url])
+      say SdrClient::Find.run(druid, url: options[:url], logger: Logger.new($stderr))
     rescue SdrClient::Credentials::NoCredentialsError
       say_error 'Log in first'
       exit(1)
@@ -71,10 +71,11 @@ module SdrClient
     option :location, enum: %w[spec music ars art hoover m&m], desc: 'Access location for the object'
     option :cdl, type: :boolean, default: false, desc: 'Controlled digital lending'
     option :cocina_file, desc: 'Path to a file containing Cocina JSON'
+    option :cocina_pipe, type: :boolean, default: false, desc: 'Indicate Cocina JSON is being piped in'
     def update(druid)
       validate_druid!(druid)
       job_id = SdrClient::Update.run(druid, **options)
-      poll_for_job_complete(job_id: job_id, url: options[:url]) # TODO: add an option that skips this
+      poll_for_job_complete(job_id: job_id, url: options[:url])
     rescue SdrClient::Credentials::NoCredentialsError
       say_error 'Log in first'
       exit(1)

--- a/lib/sdr_client/credentials.rb
+++ b/lib/sdr_client/credentials.rb
@@ -8,7 +8,7 @@ module SdrClient
     # @param [String] a json string that contains a field 'token'
     def self.write(body)
       json = JSON.parse(body)
-      Dir.mkdir(credentials_path, 0o700)
+      FileUtils.mkdir_p(credentials_path, mode: 0o700)
       File.atomic_write(credentials_file) do |file|
         file.write(json.fetch('token'))
       end


### PR DESCRIPTION
## Why was this change made? 🤔

Connects to sul-dlss/cocina-models#496

Also includes:
* Add a remediation script that fixes Catalhoyuk W3CDTF dates and shows a pattern for gluing together pipelines
* Document updating Cocina via pipe and an example of a remediation pipeline
* Change the logger in `SdrClient::CLI#get` to use stderr so that its JSON output can be piped w/o invalidating the JSON
* Fix a bug in `SdrClient::Credentials.write` when `Dir.mkdir` is called on a directory that already exists

## How was this change tested? 🤨

CI and run locally
