### PR TITLE
Add an argument for priority on Deposit#model_run

### DIFF
--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -56,21 +56,23 @@ module SdrClient
                   logger: logger).run
     end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/ParameterLists
 
     # @param [Array<String>] files absolute paths to files
     def self.model_run(request_dro:,
                        files: [],
                        url:,
                        accession:,
+                       priority: nil,
                        logger: Logger.new($stdout))
       connection = Connection.new(url: url)
       ModelProcess.new(request_dro: request_dro,
                        connection: connection,
                        files: files,
                        logger: logger,
-                       accession: accession).run
+                       accession: accession,
+                       priority: priority).run
     end
+    # rubocop:enable Metrics/ParameterLists
   end
 end
 require 'json'

--- a/lib/sdr_client/deposit/create_resource.rb
+++ b/lib/sdr_client/deposit/create_resource.rb
@@ -5,14 +5,8 @@ module SdrClient
     # Creates a resource (metadata) in SDR
     class CreateResource
       DRO_PATH = '/v1/resources'
-      # rubocop:disable Metrics/ParameterLists
-      def self.run(accession:, metadata:, logger:, connection:, assign_doi: false, priority: nil)
-        new(accession: accession,
-            priority: priority,
-            assign_doi: assign_doi,
-            metadata: metadata,
-            logger: logger,
-            connection: connection).run
+      def self.run(**args)
+        new(**args).run
       end
 
       # @param [Boolean] accession should the accessionWF be started
@@ -21,7 +15,8 @@ module SdrClient
       # @param [Hash<Symbol,String>] the result of the metadata call
       # @param [String] priority what processing priority should be used
       #                          either 'low' or 'default'
-      def initialize(accession:, assign_doi:, metadata:, logger:, connection:, priority: nil)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(accession:, metadata:, logger:, connection:, assign_doi: false, priority: nil)
         @accession = accession
         @priority = priority
         @assign_doi = assign_doi

--- a/lib/sdr_client/deposit/model_process.rb
+++ b/lib/sdr_client/deposit/model_process.rb
@@ -9,12 +9,15 @@ module SdrClient
       # @param [Cocina::Model::RequestDRO] request_dro for depositing
       # @param [Connection] connection the connection to use
       # @param [Boolean] accession should the accessionWF be started
+      # @param [String] priority (nil) what processing priority should be used
+      #                          either 'low' or 'default'
       # @param [Array<String>] files a list of file names to upload
       # @param [Boolean] assign_doi should a DOI be assigned to this item
       # @param [Logger] logger the logger to use
       def initialize(request_dro:, # rubocop:disable Metrics/ParameterLists
                      connection:,
                      accession:,
+                     priority: nil,
                      files: [],
                      assign_doi: false,
                      logger: Logger.new($stdout))
@@ -23,6 +26,7 @@ module SdrClient
         @request_dro = request_dro
         @logger = logger
         @accession = accession
+        @priority = priority
         @assign_doi = assign_doi
       end
 
@@ -36,6 +40,7 @@ module SdrClient
                                               connection: connection)
         new_request_dro = UpdateDroWithFileIdentifiers.update(request_dro: request_dro, upload_responses: upload_responses)
         CreateResource.run(accession: @accession,
+                           priority: @priority,
                            assign_doi: @assign_doi,
                            metadata: new_request_dro,
                            logger: logger,

--- a/spec/sdr_client/model_deposit_spec.rb
+++ b/spec/sdr_client/model_deposit_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SdrClient::Deposit do
   describe '.run_model' do
     subject(:run) do
       described_class.model_run(files: files, request_dro: request_dro,
-                                url: upload_url, accession: true)
+                                url: upload_url, accession: true, priority: 'low')
     end
 
     let(:process) { instance_double(SdrClient::Deposit::ModelProcess, run: true) }
@@ -29,7 +29,8 @@ RSpec.describe SdrClient::Deposit do
               request_dro: request_dro,
               connection: connection,
               logger: Logger,
-              accession: true)
+              accession: true,
+              priority: 'low')
 
       expect(process).to have_received(:run)
     end


### PR DESCRIPTION


## Why was this change made? 🤔

This allows consumers (like Google Books) who use `#model_run` to supply a priority.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡


