### PR TITLE
update cocina-models to 0.84.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     sdr-client (0.91.0)
       activesupport
-      cocina-models (~> 0.83.0)
+      cocina-models (~> 0.84.0)
       dry-monads
       faraday (>= 0.16)
 
@@ -20,7 +20,7 @@ GEM
     ast (2.4.2)
     attr_extras (6.2.5)
     byebug (11.1.3)
-    cocina-models (0.83.0)
+    cocina-models (0.84.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)

--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'cocina-models', '~> 0.83.0'
+  spec.add_dependency 'cocina-models', '~> 0.84.0'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'
 


### PR DESCRIPTION
## Why was this change made? 🤔

To get DOI exceptions for H2 in cocina 0.84.0

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡


