### PR TITLE
When updating DRO with file identifiers, allow a file identifier to n…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sdr-client (0.92.0)
+    sdr-client (0.93.0)
       activesupport
       cocina-models (~> 0.84.0)
       dry-monads
@@ -79,11 +79,13 @@ GEM
     json (2.6.2)
     jsonpath (1.1.2)
       multi_json
+    mini_portile2 (2.8.0)
     minitest (5.16.3)
     multi_json (1.15.0)
-    nokogiri (1.13.8-x86_64-darwin)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.8-x86_64-linux)
+    nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     openapi3_parser (0.9.2)
       commonmarker (~> 0.17)

--- a/lib/sdr_client/deposit/update_dro_with_file_identifiers.rb
+++ b/lib/sdr_client/deposit/update_dro_with_file_identifiers.rb
@@ -24,7 +24,7 @@ module SdrClient
       def self.updated_structural(structural, signed_ids)
         structural[:contains].each do |file_set|
           file_set[:structural][:contains].each do |file|
-            file[:externalIdentifier] = signed_ids[file[:filename]]
+            file[:externalIdentifier] = signed_ids[file[:filename]] if signed_ids.key?(file[:filename])
           end
         end
         structural

--- a/spec/sdr_client/deposit/update_dro_with_file_identifiers_spec.rb
+++ b/spec/sdr_client/deposit/update_dro_with_file_identifiers_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.describe SdrClient::Deposit::UpdateDroWithFileIdentifiers do
+  subject(:update_dro) do
+    described_class.update(request_dro: dro, upload_responses: upload_responses)
+  end
+
+  let(:druid) { 'druid:bf024yb8975' }
+
+  let(:dro_hash) do
+    {
+      cocinaVersion: Cocina::Models::VERSION,
+      externalIdentifier: druid,
+      type: Cocina::Models::ObjectType.book,
+      label: 'Test DRO',
+      version: 1,
+      description: {
+        title: [{ value: 'Test DRO' }],
+        purl: "https://purl.stanford.edu/#{druid.delete_prefix('druid:')}"
+      },
+      access: { view: 'world', download: 'world' },
+      administrative: { hasAdminPolicy: 'druid:hy787xj5878' },
+      identification: { sourceId: 'sul:abc123' },
+      structural: { contains: [
+        {
+          type: Cocina::Models::FileSetType.file,
+          externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/123-456-789', label: 'Page 1', version: 1,
+          structural: {
+            contains: [
+              {
+                type: Cocina::Models::ObjectType.file,
+                externalIdentifier: 'https://cocina.sul.stanford.edu/file/123-456-789',
+                label: '00001.html',
+                filename: '00001.html',
+                size: 0,
+                version: 1,
+                hasMimeType: 'text/html',
+                use: 'transcription',
+                hasMessageDigests: [
+                  {
+                    type: 'sha1', digest: 'cb19c405f8242d1f9a0a6180122dfb69e1d6e4c7'
+                  }, {
+                    type: 'md5', digest: 'f5eff9e28f154f79f7a11261bc0d4b30'
+                  }
+                ],
+                access: { view: 'dark' },
+                administrative: { publish: false, sdrPreserve: true, shelve: false }
+              }
+            ]
+          }
+        }
+      ] }
+    }
+  end
+
+  let(:dro) do
+    Cocina::Models::DRO.new(dro_hash)
+  end
+
+  context 'when file not included in upload responses' do
+    let(:upload_responses) do
+      [
+        SdrClient::Deposit::Files::DirectUploadResponse.new(filename: '00002.html', signed_id: 'abc123')
+      ]
+    end
+
+    it 'does not update the file' do
+      expect(update_dro.structural.contains.first.structural.contains.first.externalIdentifier).to eq('https://cocina.sul.stanford.edu/file/123-456-789')
+    end
+  end
+
+  context 'when file included in upload responses' do
+    let(:upload_responses) do
+      [
+        SdrClient::Deposit::Files::DirectUploadResponse.new(filename: '00001.html', signed_id: 'abc123')
+      ]
+    end
+
+    it 'does updates the file' do
+      expect(update_dro.structural.contains.first.structural.contains.first.externalIdentifier).to eq('abc123')
+    end
+  end
+end


### PR DESCRIPTION
…ot exist.

## Why was this change made? 🤔
We want to be able to only update some file identifiers.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡


