### PR TITLE
Revert "update cocina-models to 0.85.0" due to EMPTY parallelContributor presence

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     sdr-client (0.95.0)
       activesupport
-      cocina-models (~> 0.85.0)
+      cocina-models (~> 0.84.0)
       dry-monads
       faraday (>= 0.16)
 
@@ -20,7 +20,7 @@ GEM
     ast (2.4.2)
     attr_extras (6.2.5)
     byebug (11.1.3)
-    cocina-models (0.85.0)
+    cocina-models (0.84.5)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -98,7 +98,7 @@ GEM
     racc (1.6.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.6.0)
+    regexp_parser (2.5.0)
     rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
@@ -175,4 +175,4 @@ DEPENDENCIES
   webmock (~> 3.7)
 
 BUNDLED WITH
-   2.3.22
+   2.3.17

--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'cocina-models', '~> 0.85.0'
+  spec.add_dependency 'cocina-models', '~> 0.84.0'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'
 


### PR DESCRIPTION
Reverts sul-dlss/sdr-client#232