### PR TITLE
Fix CLI usage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,8 +4,10 @@ PATH
     sdr-client (2.0.0)
       activesupport
       cocina-models (~> 0.86.0)
+      config
       dry-monads
       faraday (>= 0.16)
+      launchy
 
 GEM
   remote: https://rubygems.org/
@@ -189,8 +191,6 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   byebug
-  config
-  launchy
   rake (~> 13.0)
   rspec (~> 3.0)
   rspec_junit_formatter

--- a/lib/sdr_client/cli/config.rb
+++ b/lib/sdr_client/cli/config.rb
@@ -27,4 +27,6 @@ Config.setup do |config|
   config.env_converter = :downcase
 end
 
-Config.load_and_set_settings('config/settings.yml')
+Config.load_and_set_settings(
+  File.join(__dir__, '../../..', 'config/settings.yml')
+)

--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -29,12 +29,12 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'cocina-models', '~> 0.86.0'
+  spec.add_dependency 'config'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'
+  spec.add_dependency 'launchy'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'config'
-  spec.add_development_dependency 'launchy'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.24'


### PR DESCRIPTION
# Why was this change made? 🤔

Andrew reported problems today when using the CLI after running `gem install sdr-client`, which is how we are expecting our API partners to use the CLI. These commits make the CLI work in that context.

- Move launchy and config to prod dependencies
- Resolve where to find settings

# How was this change tested? 🤨

CI + tested locally
