### PR TITLE
bump cocina-models to 0.90.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     sdr-client (2.3.1)
       activesupport
-      cocina-models (~> 0.89.0)
+      cocina-models (~> 0.90.0)
       config
       dry-monads
       faraday (>= 0.16)
@@ -22,7 +22,7 @@ GEM
     ast (2.4.2)
     attr_extras (7.1.0)
     byebug (11.1.3)
-    cocina-models (0.89.1)
+    cocina-models (0.90.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
@@ -137,7 +137,7 @@ GEM
     rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.4)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -206,4 +206,4 @@ DEPENDENCIES
   webmock (~> 3.7)
 
 BUNDLED WITH
-   2.3.17
+   2.3.22

--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'cocina-models', '~> 0.89.0'
+  spec.add_dependency 'cocina-models', '~> 0.90.0'
   spec.add_dependency 'config'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'


### PR DESCRIPTION
## Why was this change made? 🤔

beats working

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡


