### PR TITLE
handle invalid json and content type cleanup

### DIFF
--- a/lib/sdr_client/deposit/files/direct_upload_request.rb
+++ b/lib/sdr_client/deposit/files/direct_upload_request.rb
@@ -10,18 +10,35 @@ module SdrClient
           checksum = Digest::MD5.file(path).base64digest
           new(checksum: checksum,
               byte_size: ::File.size(path),
-              content_type: content_type || 'application/octet-stream',
+              content_type: clean_content_type(content_type),
               filename: file_name)
         end
 
         def as_json
           {
-            blob: { filename: filename, byte_size: byte_size, checksum: checksum, content_type: content_type }
+            blob: { filename: filename, byte_size: byte_size, checksum: checksum,
+                    content_type: self.class.clean_content_type(content_type) }
           }
         end
 
         def to_json(*_args)
           JSON.generate(as_json)
+        end
+
+        def self.clean_content_type(content_type)
+          # Invalid JSON files with a content type of application/json will trigger 400 errors in sdr-api
+          # since they are parsed and rejected (not clear why and what part of the stack is doing this).
+          # The work around is to change the content_type for any JSON files to something different and
+          # specific to avoid the parsing, and thaen have this changed back to application/json after .
+          # upload is complete. There is a similar change in sdr-api to change the content_type back.
+          # See https://github.com/sul-dlss/happy-heron/issues/3075 for the original bug report
+          # See https://github.com/sul-dlss/sdr-api/pull/585 for the change in sdr-api
+          return 'application/octet-stream' if content_type.blank?
+
+          return 'application/x-stanford-json' if content_type == 'application/json'
+
+          # ActiveStorage is expecting "application/x-stata-dta" not "application/x-stata-dta;version=14"
+          content_type.split(';')&.first
         end
       end
     end

--- a/lib/sdr_client/deposit/files/direct_upload_request.rb
+++ b/lib/sdr_client/deposit/files/direct_upload_request.rb
@@ -10,14 +10,14 @@ module SdrClient
           checksum = Digest::MD5.file(path).base64digest
           new(checksum: checksum,
               byte_size: ::File.size(path),
-              content_type: clean_content_type(content_type),
+              content_type: clean_and_translate_content_type(content_type),
               filename: file_name)
         end
 
         def as_json
           {
             blob: { filename: filename, byte_size: byte_size, checksum: checksum,
-                    content_type: self.class.clean_content_type(content_type) }
+                    content_type: self.class.clean_and_translate_content_type(content_type) }
           }
         end
 
@@ -27,18 +27,19 @@ module SdrClient
 
         # Invalid JSON files with a content type of application/json will trigger 400 errors in sdr-api
         # since they are parsed and rejected (not clear why and what part of the stack is doing this).
-        # The work around is to change the content_type for any JSON files to something different and
-        # specific to avoid the parsing, and thaen have this changed back to application/json after .
-        # upload is complete. There is a similar change in sdr-api to change the content_type back.
+        # The work around is to change the content_type for any JSON files to a custom stand-in and
+        # specific to avoid the parsing, and then have this translated back to application/json after .
+        # upload is complete. There is a corresponding change in sdr-api to translate the content_type back
+        # before the Cocina is saved.
         # See https://github.com/sul-dlss/happy-heron/issues/3075 for the original bug report
         # See https://github.com/sul-dlss/sdr-api/pull/585 for the change in sdr-api
-        def self.clean_content_type(content_type)
+        def self.clean_and_translate_content_type(content_type)
           return 'application/octet-stream' if content_type.blank?
 
-          return 'application/x-stanford-json' if content_type == 'application/json'
-
           # ActiveStorage is expecting "application/x-stata-dta" not "application/x-stata-dta;version=14"
-          content_type.split(';')&.first
+          content_type = content_type.split(';')&.first
+
+          content_type == 'application/json' ? 'application/x-stanford-json' : content_type
         end
       end
     end

--- a/lib/sdr_client/deposit/files/direct_upload_request.rb
+++ b/lib/sdr_client/deposit/files/direct_upload_request.rb
@@ -25,14 +25,14 @@ module SdrClient
           JSON.generate(as_json)
         end
 
+        # Invalid JSON files with a content type of application/json will trigger 400 errors in sdr-api
+        # since they are parsed and rejected (not clear why and what part of the stack is doing this).
+        # The work around is to change the content_type for any JSON files to something different and
+        # specific to avoid the parsing, and thaen have this changed back to application/json after .
+        # upload is complete. There is a similar change in sdr-api to change the content_type back.
+        # See https://github.com/sul-dlss/happy-heron/issues/3075 for the original bug report
+        # See https://github.com/sul-dlss/sdr-api/pull/585 for the change in sdr-api
         def self.clean_content_type(content_type)
-          # Invalid JSON files with a content type of application/json will trigger 400 errors in sdr-api
-          # since they are parsed and rejected (not clear why and what part of the stack is doing this).
-          # The work around is to change the content_type for any JSON files to something different and
-          # specific to avoid the parsing, and thaen have this changed back to application/json after .
-          # upload is complete. There is a similar change in sdr-api to change the content_type back.
-          # See https://github.com/sul-dlss/happy-heron/issues/3075 for the original bug report
-          # See https://github.com/sul-dlss/sdr-api/pull/585 for the change in sdr-api
           return 'application/octet-stream' if content_type.blank?
 
           return 'application/x-stanford-json' if content_type == 'application/json'

--- a/spec/sdr_client/deposit/files/direct_upload_request_spec.rb
+++ b/spec/sdr_client/deposit/files/direct_upload_request_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+RSpec.describe SdrClient::Deposit::Files::DirectUploadRequest do
+  describe '.from_file' do
+    it 'sets blank content_type to application/octet-stream' do
+      expect(described_class.from_file('spec/fixtures/file1.txt', file_name: 'file1.png', content_type: ''))
+        .to have_attributes(
+          filename: 'file1.png', content_type: 'application/octet-stream', byte_size: 27,
+          checksum: 'hagfaf2F1Cx0r3jnHtIe9Q=='
+        )
+    end
+
+    it 'sets nil content_type to application/octet-stream' do
+      expect(described_class.from_file('spec/fixtures/file1.txt', file_name: 'file1.png', content_type: nil))
+        .to have_attributes(
+          filename: 'file1.png', content_type: 'application/octet-stream', byte_size: 27,
+          checksum: 'hagfaf2F1Cx0r3jnHtIe9Q=='
+        )
+    end
+
+    it 'sets application/json content_type to application/x-stanford-json' do
+      expect(described_class.from_file('spec/fixtures/file1.txt', file_name: 'file1.png',
+                                                                  content_type: 'application/json'))
+        .to have_attributes(filename: 'file1.png', content_type: 'application/x-stanford-json', byte_size: 27,
+                            checksum: 'hagfaf2F1Cx0r3jnHtIe9Q==')
+    end
+
+    it 'leaves application/xml content_type alone' do
+      expect(described_class.from_file('spec/fixtures/file1.txt', file_name: 'file1.png',
+                                                                  content_type: 'application/xml'))
+        .to have_attributes(filename: 'file1.png', content_type: 'application/xml', byte_size: 27,
+                            checksum: 'hagfaf2F1Cx0r3jnHtIe9Q==')
+    end
+
+    it 'removes extra part of content_type after semicolon' do
+      expect(described_class.from_file('spec/fixtures/file1.txt', file_name: 'file1.png',
+                                                                  content_type: 'application/x-stata-dta;version=14'))
+        .to have_attributes(filename: 'file1.png', content_type: 'application/x-stata-dta', byte_size: 27,
+                            checksum: 'hagfaf2F1Cx0r3jnHtIe9Q==')
+    end
+  end
+
+  describe '.as_json' do
+    it 'sets blank content_type to application/octet-stream' do
+      expect(described_class.new(filename: 'file1.png', checksum: '1234', byte_size: 27, content_type: '').as_json)
+        .to eq({ blob: { filename: 'file1.png', byte_size: 27, checksum: '1234',
+                         content_type: 'application/octet-stream' } })
+    end
+
+    it 'sets nil content_type to application/octet-stream' do
+      expect(described_class.new(filename: 'file1.png', checksum: '1234', byte_size: 27, content_type: nil).as_json)
+        .to eq({ blob: { filename: 'file1.png', byte_size: 27, checksum: '1234',
+                         content_type: 'application/octet-stream' } })
+    end
+
+    it 'sets application/json content_type to application/x-stanford-json' do
+      expect(described_class.new(filename: 'file1.png', checksum: '1234', byte_size: 27,
+                                 content_type: 'application/json').as_json)
+        .to eq({ blob: { filename: 'file1.png', byte_size: 27, checksum: '1234',
+                         content_type: 'application/x-stanford-json' } })
+    end
+
+    it 'leaves application/xml content_type alone' do
+      expect(described_class.new(filename: 'file1.png', checksum: '1234', byte_size: 27,
+                                 content_type: 'application/xml').as_json)
+        .to eq({ blob: { filename: 'file1.png', byte_size: 27, checksum: '1234', content_type: 'application/xml' } })
+    end
+
+    it 'removes extra part of content_type after semicolon' do
+      expect(described_class.new(filename: 'file1.png', checksum: '1234', byte_size: 27,
+                                 content_type: 'application/x-stata-dta;version=14').as_json)
+        .to eq({ blob: { filename: 'file1.png', byte_size: 27, checksum: '1234',
+                         content_type: 'application/x-stata-dta' } })
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Push content type cleanup and setting from H2 into the client so all consumers can benefit.

Part of sul-dlss/happy-heron#3075

Goes with https://github.com/sul-dlss/sdr-api/pull/585
Replaces https://github.com/sul-dlss/happy-heron/pull/3082

## How was this change tested? 🤨

New tests added and in QA with H2