### PR TITLE
upgrade to latest version of cocina-models

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     sdr-client (2.6.0)
       activesupport
-      cocina-models (~> 0.91.0)
+      cocina-models (~> 0.92.0)
       config
       dry-monads
       faraday (>= 0.16)
@@ -29,13 +29,14 @@ GEM
     base64 (0.1.1)
     bigdecimal (3.1.4)
     byebug (11.1.3)
-    cocina-models (0.91.4)
+    cocina-models (0.92.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       edtf
       equivalent-xml
+      i18n
       jsonpath
       nokogiri
       openapi3_parser
@@ -206,6 +207,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux

--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'cocina-models', '~> 0.91.0'
+  spec.add_dependency 'cocina-models', '~> 0.92.0'
   spec.add_dependency 'config'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'


### PR DESCRIPTION
## Why was this change made? 🤔

part of upgrading SDR apps to new cocina-models release

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡


