### PR TITLE
Use zeitwerk to auto-load internal dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
       dry-monads
       faraday (>= 0.16)
       launchy
+      zeitwerk
 
 GEM
   remote: https://rubygems.org/

--- a/lib/sdr_client.rb
+++ b/lib/sdr_client.rb
@@ -1,21 +1,24 @@
 # frozen_string_literal: true
 
+require 'zeitwerk'
+# Zeitwerk doesn't auto-load these dependencies
 require 'dry/monads'
 require 'faraday'
 require 'active_support'
 require 'active_support/core_ext'
 require 'cocina/models'
 
-require 'sdr_client/version'
-require 'sdr_client/unexpected_response'
-require 'sdr_client/deposit'
-require 'sdr_client/update'
-require 'sdr_client/credentials'
-require 'sdr_client/find'
-require 'sdr_client/login'
-require 'sdr_client/login_prompt'
-require 'sdr_client/connection'
-require 'sdr_client/background_job_results'
+loader = Zeitwerk::Loader.for_gem
+loader.ignore(
+  "#{__dir__}/sdr-client.rb",
+  "#{__dir__}/sdr_client/cli.rb",
+  "#{__dir__}/sdr_client/cli/config.rb"
+)
+loader.inflector.inflect(
+  'md5' => 'MD5',
+  'sha1' => 'SHA1'
+)
+loader.setup
 
 module SdrClient
   class Error < StandardError; end

--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'
   spec.add_dependency 'launchy'
+  spec.add_dependency 'zeitwerk'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
-require 'bundler/setup'
-require 'byebug'
-require 'webmock/rspec'
+# It is advised to load simplecov before everything else
 require 'simplecov'
 
 SimpleCov.start do
   add_filter '/spec/'
   add_filter 'lib/sdr_client/cli.rb'
+  add_filter 'lib/sdr_client/cli/'
 end
 
-require 'cocina/models'
-require 'cocina/rspec'
+require 'bundler/setup'
 require 'sdr_client'
+require 'cocina/rspec'
+require 'byebug'
+require 'webmock/rspec'
 
 Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))].each { |f| require f }
 


### PR DESCRIPTION
# Why was this change made?

It makes sure we are naming classes and modules per community norms and it also makes gems more easily extensible.

It also sets us up to merge currently in progress refactoring (#326).

# How was this change tested?

- [x] CI
- [x] integration tests in stage (to make sure sdr-client changes don't break argo, gbooks, or h2)
