### PR TITLE
Remove explicit require statements

### DIFF
--- a/lib/sdr_client/background_job_results.rb
+++ b/lib/sdr_client/background_job_results.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 module SdrClient
   # API calls around background job results from dor-services-app
   module BackgroundJobResults

--- a/lib/sdr_client/deposit.rb
+++ b/lib/sdr_client/deposit.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'logger'
-
 module SdrClient
   # The namespace for the "deposit" command
   module Deposit
@@ -88,22 +86,3 @@ module SdrClient
     # rubocop:enable Metrics/ParameterLists
   end
 end
-require 'json'
-require 'sdr_client/deposit/create_resource'
-require 'sdr_client/deposit/single_file_grouping_strategy'
-require 'sdr_client/deposit/matching_file_grouping_strategy'
-require 'sdr_client/deposit/file_type_file_set_strategy'
-require 'sdr_client/deposit/image_file_set_strategy'
-require 'sdr_client/deposit/files/direct_upload_request'
-require 'sdr_client/deposit/files/direct_upload_response'
-require 'sdr_client/deposit/file'
-require 'sdr_client/deposit/file_metadata_builder'
-require 'sdr_client/deposit/file_set'
-require 'sdr_client/deposit/request'
-require 'sdr_client/deposit/metadata_builder'
-require 'sdr_client/deposit/model_process'
-require 'sdr_client/deposit/process'
-require 'sdr_client/deposit/update_resource'
-require 'sdr_client/deposit/update_dro_with_file_identifiers'
-require 'sdr_client/deposit/upload_files'
-require 'sdr_client/deposit/upload_files_metadata_builder'

--- a/lib/sdr_client/deposit/file_metadata_builder.rb
+++ b/lib/sdr_client/deposit/file_metadata_builder.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require 'sdr_client/deposit/file_metadata_builder_operations/mime_type'
-require 'sdr_client/deposit/file_metadata_builder_operations/md5'
-require 'sdr_client/deposit/file_metadata_builder_operations/sha1'
-
 module SdrClient
   module Deposit
     # Build basic metadata for files, iterating over a series of operations

--- a/lib/sdr_client/deposit/file_metadata_builder_operations/md5.rb
+++ b/lib/sdr_client/deposit/file_metadata_builder_operations/md5.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'digest'
-
 module SdrClient
   module Deposit
     module FileMetadataBuilderOperations

--- a/lib/sdr_client/deposit/file_metadata_builder_operations/mime_type.rb
+++ b/lib/sdr_client/deposit/file_metadata_builder_operations/mime_type.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'shellwords'
-
 module SdrClient
   module Deposit
     module FileMetadataBuilderOperations

--- a/lib/sdr_client/deposit/file_metadata_builder_operations/sha1.rb
+++ b/lib/sdr_client/deposit/file_metadata_builder_operations/sha1.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'digest'
-
 module SdrClient
   module Deposit
     module FileMetadataBuilderOperations

--- a/lib/sdr_client/deposit/files/direct_upload_request.rb
+++ b/lib/sdr_client/deposit/files/direct_upload_request.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'digest'
-
 module SdrClient
   module Deposit
     module Files

--- a/lib/sdr_client/deposit/metadata_builder.rb
+++ b/lib/sdr_client/deposit/metadata_builder.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'logger'
-
 module SdrClient
   module Deposit
     # Constructs the deposit metadata for the DRO

--- a/lib/sdr_client/deposit/model_process.rb
+++ b/lib/sdr_client/deposit/model_process.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'logger'
-
 module SdrClient
   module Deposit
     # The process for doing a deposit from a Cocina Model

--- a/lib/sdr_client/deposit/process.rb
+++ b/lib/sdr_client/deposit/process.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'logger'
-
 module SdrClient
   module Deposit
     # The process for doing a deposit

--- a/lib/sdr_client/deposit/upload_files.rb
+++ b/lib/sdr_client/deposit/upload_files.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'logger'
-
 module SdrClient
   module Deposit
     # The file uploading part of a deposit

--- a/lib/sdr_client/deposit/upload_files_metadata_builder.rb
+++ b/lib/sdr_client/deposit/upload_files_metadata_builder.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'logger'
-
 module SdrClient
   module Deposit
     # Collecting all the metadata about the files for a deposit

--- a/lib/sdr_client/find.rb
+++ b/lib/sdr_client/find.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'logger'
-
 module SdrClient
   # The namespace for the "get" command
   module Find

--- a/lib/sdr_client/login_prompt.rb
+++ b/lib/sdr_client/login_prompt.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'io/console'
-
 module SdrClient
   # The namespace for the "login" command
   module LoginPrompt


### PR DESCRIPTION
# Why was this change made?

They are no longer necessary now that sdr-client uses zeitwerk to auto-load its dependencies. Ideally I would have remembered this step before cutting release 2.11.0. So here comes release 2.11.1...

# How was this change tested?

- [x] CI
- [x] Point a dependent codebase (e.g., Argo) at the PR branch, deploy it, run integration tests that use argo and sdr-client
