### PR TITLE
Add JSON content type to token authentication

### DIFF
--- a/lib/sdr_client/redesigned_client/authenticator.rb
+++ b/lib/sdr_client/redesigned_client/authenticator.rb
@@ -10,7 +10,7 @@ module SdrClient
 
       # Request an access_token
       def token
-        response = connection.post(path, request_body)
+        response = connection.post(path, request_body, content_type: 'application/json')
 
         UnexpectedResponse.call(response) unless response.success?
 


### PR DESCRIPTION
# Why was this change made?

This fixes a bug that only came up when testing Google-Books in QA: the connection to refresh the token needs to specify the JSON content type.

# How was this change tested?

CI & QA
