### PR TITLE
Adds user_versions parameter.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,9 @@ Naming/FileName:
   Exclude:
     - 'lib/sdr-client.rb'
 
+RSpec/MultipleExpectations:
+  Enabled: false
+
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -88,20 +88,6 @@ RSpec/MessageSpies:
   Exclude:
     - 'spec/sdr_client/deposit_spec.rb'
 
-# Offense count: 19
-# Configuration parameters: Max.
-RSpec/MultipleExpectations:
-  Exclude:
-    - 'spec/sdr_client/connection_spec.rb'
-    - 'spec/sdr_client/deposit/metadata_builder_spec.rb'
-    - 'spec/sdr_client/deposit_model_spec.rb'
-    - 'spec/sdr_client/deposit_spec.rb'
-    - 'spec/sdr_client/find_spec.rb'
-    - 'spec/sdr_client/login_spec.rb'
-    - 'spec/sdr_client/redesigned_client/deposit_spec.rb'
-    - 'spec/sdr_client/redesigned_client/job_status_spec.rb'
-    - 'spec/sdr_client/redesigned_client/upload_files_spec.rb'
-
 # Offense count: 24
 # Configuration parameters: EnforcedStyle, IgnoreSharedExamples.
 # SupportedStyles: always, named_only

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
+    nokogiri (1.16.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
@@ -195,6 +197,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/lib/sdr_client/deposit/create_resource.rb
+++ b/lib/sdr_client/deposit/create_resource.rb
@@ -5,8 +5,8 @@ module SdrClient
     # Creates a resource (metadata) in SDR
     class CreateResource
       DRO_PATH = '/v1/resources'
-      def self.run(**args)
-        new(**args).run
+      def self.run(...)
+        new(...).run
       end
 
       # @param [Boolean] accession should the accessionWF be started
@@ -15,14 +15,16 @@ module SdrClient
       # @param [Hash<Symbol,String>] the result of the metadata call
       # @param [String] priority what processing priority should be used
       #                          either 'low' or 'default'
+      # @param [String] user_versions action (none, new, update) to take for user version when closing version
       # rubocop:disable Metrics/ParameterLists
-      def initialize(accession:, metadata:, logger:, connection:, assign_doi: false, priority: nil)
+      def initialize(accession:, metadata:, logger:, connection:, assign_doi: false, priority: nil, user_versions: nil)
         @accession = accession
         @priority = priority
         @assign_doi = assign_doi
         @metadata = metadata
         @logger = logger
         @connection = connection
+        @user_versions = user_versions
       end
       # rubocop:enable Metrics/ParameterLists
 
@@ -39,7 +41,7 @@ module SdrClient
 
       private
 
-      attr_reader :metadata, :logger, :connection, :priority
+      attr_reader :metadata, :logger, :connection, :priority, :user_versions
 
       def metadata_request
         json = metadata.to_json
@@ -62,6 +64,7 @@ module SdrClient
         params = { accession: accession? }
         params[:priority] = priority if priority
         params[:assign_doi] = true if assign_doi? # false is default
+        params[:user_versions] = user_versions if user_versions.present?
         DRO_PATH + '?' + params.map { |k, v| "#{k}=#{v}" }.join('&')
       end
     end

--- a/lib/sdr_client/deposit/update_resource.rb
+++ b/lib/sdr_client/deposit/update_resource.rb
@@ -6,18 +6,20 @@ module SdrClient
     class UpdateResource
       DRO_PATH = '/v1/resources/%<id>s'
 
-      def self.run(metadata:, logger:, connection:, version_description: nil)
-        new(metadata: metadata, logger: logger, connection: connection, version_description: version_description).run
+      def self.run(...)
+        new(...).run
       end
 
       # @param [Cocina::Models::DRO] metadata
       # @param [Hash<Symbol,String>] the result of the metadata call
       # @param [String] version_description
-      def initialize(metadata:, logger:, connection:, version_description: nil)
+      # @param [String] user_versions action (none, new, update) to take for user version when closing version
+      def initialize(metadata:, logger:, connection:, version_description: nil, user_versions: nil)
         @metadata = metadata
         @logger = logger
         @connection = connection
         @version_description = version_description
+        @user_versions = user_versions
       end
 
       # @param [Hash<Symbol,String>] the result of the metadata call
@@ -33,8 +35,9 @@ module SdrClient
 
       private
 
-      attr_reader :metadata, :logger, :connection, :version_description
+      attr_reader :metadata, :logger, :connection, :version_description, :user_versions
 
+      # rubocop:disable Metrics/AbcSize
       def metadata_request
         json = metadata.to_json
         logger.debug("Starting update metadata: #{json}")
@@ -43,8 +46,10 @@ module SdrClient
                        'Content-Type' => 'application/json',
                        'X-Cocina-Models-Version' => Cocina::Models::VERSION) do |req|
                          req.params['versionDescription'] = version_description if version_description
+                         req.params['user_versions'] = user_versions if user_versions.present?
                        end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def path(metadata)
         format(DRO_PATH, id: metadata.externalIdentifier)

--- a/lib/sdr_client/redesigned_client/create_resource.rb
+++ b/lib/sdr_client/redesigned_client/create_resource.rb
@@ -14,11 +14,13 @@ module SdrClient
       # @param [Hash<Symbol,String>] the result of the metadata call
       # @param [String] priority what processing priority should be used
       #                          either 'low' or 'default'
-      def initialize(accession:, metadata:, assign_doi: false, priority: nil)
+      # @param [String] user_versions action (none, new, update) to take for user version when closing version
+      def initialize(accession:, metadata:, assign_doi: false, priority: nil, user_versions: nil)
         @accession = accession
         @priority = priority
         @assign_doi = assign_doi
         @metadata = metadata
+        @user_versions = user_versions
       end
 
       # @param [Hash<Symbol,String>] the result of the metadata call
@@ -41,7 +43,7 @@ module SdrClient
 
       private
 
-      attr_reader :metadata, :priority
+      attr_reader :metadata, :priority, :user_versions
 
       def logger
         SdrClient::RedesignedClient.config.logger
@@ -63,6 +65,7 @@ module SdrClient
         params = { accession: accession? }
         params[:priority] = priority if priority
         params[:assign_doi] = true if assign_doi? # false is default
+        params[:user_versions] = user_versions if user_versions.present?
         query_string = params.map { |k, v| "#{k}=#{v}" }.join('&')
         "/v1/resources?#{query_string}"
       end

--- a/lib/sdr_client/redesigned_client/update_resource.rb
+++ b/lib/sdr_client/redesigned_client/update_resource.rb
@@ -12,9 +12,11 @@ module SdrClient
 
       # @param [Cocina::Models::DRO] model
       # @param [String] version_description
-      def initialize(model:, version_description: nil)
+      # @param [String] user_versions action (none, new, update) to take for user version when closing version
+      def initialize(model:, version_description: nil, user_versions: nil)
         @model = model
         @version_description = version_description
+        @user_versions = user_versions
       end
 
       # @return [String] job id for the background job result
@@ -37,7 +39,7 @@ module SdrClient
 
       private
 
-      attr_reader :model, :version_description
+      attr_reader :model, :version_description, :user_versions
 
       def client
         SdrClient::RedesignedClient.instance
@@ -52,9 +54,10 @@ module SdrClient
       end
 
       def request_params
-        return { 'versionDescription' => version_description } if version_description
-
-        {}
+        {
+          versionDescription: version_description,
+          user_versions: user_versions
+        }.compact
       end
     end
   end

--- a/spec/sdr_client/deposit/update_resource_spec.rb
+++ b/spec/sdr_client/deposit/update_resource_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SdrClient::Deposit::UpdateResource do
   describe 'run' do
     subject(:request) do
       described_class.run(metadata: metadata, logger: logger, connection: connection,
-                          version_description: 'Updated metadata')
+                          version_description: 'Updated metadata', user_versions: 'new')
     end
 
     let(:dro_hash) do
@@ -32,7 +32,7 @@ RSpec.describe SdrClient::Deposit::UpdateResource do
 
     context 'when it is successful' do
       before do
-        stub_request(:put, 'https://sdr-api-prod.stanford.edu/v1/resources/druid:gf123df7654?versionDescription=Updated%20metadata')
+        stub_request(:put, 'https://sdr-api-prod.stanford.edu/v1/resources/druid:gf123df7654?versionDescription=Updated%20metadata&user_versions=new')
           .with(
             body: metadata.to_json
           )
@@ -44,7 +44,7 @@ RSpec.describe SdrClient::Deposit::UpdateResource do
 
     context 'when there is an error' do
       before do
-        stub_request(:put, 'https://sdr-api-prod.stanford.edu/v1/resources/druid:gf123df7654?versionDescription=Updated%20metadata')
+        stub_request(:put, 'https://sdr-api-prod.stanford.edu/v1/resources/druid:gf123df7654?versionDescription=Updated%20metadata&user_versions=new')
           .with(
             body: metadata.to_json
           )

--- a/spec/sdr_client/redesigned_client/create_resource_spec.rb
+++ b/spec/sdr_client/redesigned_client/create_resource_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SdrClient::RedesignedClient::CreateResource do
   end
 
   describe '#run' do
-    subject(:creator) { described_class.new(accession: false, metadata: model) }
+    subject(:creator) { described_class.new(accession: false, metadata: model, user_versions: 'update') }
 
     let(:fake_connection) { instance_double(Faraday::Connection, post: fake_http_response) }
     let(:fake_http_response) do
@@ -43,7 +43,9 @@ RSpec.describe SdrClient::RedesignedClient::CreateResource do
 
     it 'posts the JSON to the API' do
       creator.run
-      expect(fake_connection).to have_received(:post).once
+      expect(fake_connection).to have_received(:post).once do |post|
+        expect(post).to eq('/v1/resources?accession=false&user_versions=update')
+      end
     end
 
     it 'logs the API response JSON' do

--- a/spec/sdr_client/redesigned_client/update_resource_spec.rb
+++ b/spec/sdr_client/redesigned_client/update_resource_spec.rb
@@ -58,5 +58,12 @@ RSpec.describe SdrClient::RedesignedClient::UpdateResource do
 
       it { is_expected.to eq 9 }
     end
+
+    context 'with a user_versions' do
+      let(:optional_params) { { user_versions: 'none' } }
+      let(:update_url) { 'http://example.com/v1/resources/druid:gf123df7654?user_versions=none' }
+
+      it { is_expected.to eq 9 }
+    end
   end
 end


### PR DESCRIPTION
closes #354

## Why was this change made? 🤔
So that H2 can pass a user_version parameter to SDR API.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit
