### PR TITLE
Connect new `user_versions` param with the new interface

### DIFF
--- a/lib/sdr_client/redesigned_client/deposit.rb
+++ b/lib/sdr_client/redesigned_client/deposit.rb
@@ -15,6 +15,7 @@ module SdrClient
       # @param [Hash] options optional parameters
       # @option options [Boolean] assign_doi should a DOI be assigned to this item
       # @option options [String] priority what processing priority should be used ('low', 'default')
+      # @option options [String] user_versions action (none, new, update) to take for user version when closing version
       # @option options [String] grouping_strategy what strategy will be used to group files
       # @option options [String] file_set_strategy what strategy will be used to group file sets
       # @option options [RequestBuilder] request_builder a request builder instance
@@ -48,6 +49,7 @@ module SdrClient
         CreateResource.run(accession: accession,
                            priority: options[:priority],
                            assign_doi: options[:assign_doi],
+                           user_versions: options[:user_versions],
                            metadata: new_request_dro)
       end
 

--- a/spec/sdr_client/redesigned_client/deposit_spec.rb
+++ b/spec/sdr_client/redesigned_client/deposit_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SdrClient::RedesignedClient::Deposit do
   let(:file_name) { 'file1.txt' }
   let(:files) { [file_name] }
   let(:model) { build(:request_dro).new(**attributes) }
-  let(:options) { { priority: 'low', assign_doi: true } }
+  let(:options) { { priority: 'low', assign_doi: true, user_versions: 'none' } }
   let(:url) { 'https://sdr-api.example.edu' }
 
   before do


### PR DESCRIPTION
# Why was this change made?

The new interface does not support direct interaction with the `CreateResource` class, so this new param must be passed from the `Deposit` instance.

# How was this change tested?

CI
