### PR TITLE
Bump cocina-models to 0.98.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     sdr-client (2.15.0)
       activesupport
-      cocina-models (~> 0.97.0)
+      cocina-models (~> 0.98.0)
       config
       dry-monads
       faraday (>= 0.16)
@@ -31,7 +31,7 @@ GEM
     bigdecimal (3.1.8)
     byebug (11.1.3)
     childprocess (5.0.0)
-    cocina-models (0.97.0)
+    cocina-models (0.98.0)
       activesupport
       deprecation
       dry-struct (~> 1.0)

--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'cocina-models', '~> 0.97.0'
+  spec.add_dependency 'cocina-models', '~> 0.98.0'
   spec.add_dependency 'config'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'


### PR DESCRIPTION
## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡


