### PR TITLE
Add support for accession param when updating.

### DIFF
--- a/lib/sdr_client/deposit/update_resource.rb
+++ b/lib/sdr_client/deposit/update_resource.rb
@@ -14,12 +14,14 @@ module SdrClient
       # @param [Hash<Symbol,String>] the result of the metadata call
       # @param [String] version_description
       # @param [String] user_versions action (none, new, update) to take for user version when closing version
-      def initialize(metadata:, logger:, connection:, version_description: nil, user_versions: nil)
+      # @param [Boolean] accession true if accessioning should be performed
+      def initialize(metadata:, logger:, connection:, version_description: nil, user_versions: nil, accession: true) # rubocop:disable Metrics/ParameterLists
         @metadata = metadata
         @logger = logger
         @connection = connection
         @version_description = version_description
         @user_versions = user_versions
+        @accession = accession
       end
 
       # @param [Hash<Symbol,String>] the result of the metadata call
@@ -35,7 +37,7 @@ module SdrClient
 
       private
 
-      attr_reader :metadata, :logger, :connection, :version_description, :user_versions
+      attr_reader :metadata, :logger, :connection, :version_description, :user_versions, :accession
 
       # rubocop:disable Metrics/AbcSize
       def metadata_request
@@ -47,6 +49,7 @@ module SdrClient
                        'X-Cocina-Models-Version' => Cocina::Models::VERSION) do |req|
                          req.params['versionDescription'] = version_description if version_description
                          req.params['user_versions'] = user_versions if user_versions.present?
+                         req.params['accession'] = true if accession
                        end
       end
       # rubocop:enable Metrics/AbcSize

--- a/lib/sdr_client/redesigned_client/update_resource.rb
+++ b/lib/sdr_client/redesigned_client/update_resource.rb
@@ -13,10 +13,12 @@ module SdrClient
       # @param [Cocina::Models::DRO] model
       # @param [String] version_description
       # @param [String] user_versions action (none, new, update) to take for user version when closing version
-      def initialize(model:, version_description: nil, user_versions: nil)
+      # @param [Boolean] accession true if accessioning should be performed
+      def initialize(model:, version_description: nil, user_versions: nil, accession: true)
         @model = model
         @version_description = version_description
         @user_versions = user_versions
+        @accession = accession
       end
 
       # @return [String] job id for the background job result
@@ -39,7 +41,7 @@ module SdrClient
 
       private
 
-      attr_reader :model, :version_description, :user_versions
+      attr_reader :model, :version_description, :user_versions, :accession
 
       def client
         SdrClient::RedesignedClient.instance
@@ -56,7 +58,8 @@ module SdrClient
       def request_params
         {
           versionDescription: version_description,
-          user_versions: user_versions
+          user_versions: user_versions,
+          accession: accession ? true : nil
         }.compact
       end
     end

--- a/spec/sdr_client/deposit/update_resource_spec.rb
+++ b/spec/sdr_client/deposit/update_resource_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe SdrClient::Deposit::UpdateResource do
 
     context 'when it is successful' do
       before do
-        stub_request(:put, 'https://sdr-api-prod.stanford.edu/v1/resources/druid:gf123df7654?versionDescription=Updated%20metadata&user_versions=new')
+        stub_request(:put, 'https://sdr-api-prod.stanford.edu/v1/resources/druid:gf123df7654?versionDescription=Updated%20metadata&user_versions=new&accession=true')
           .with(
             body: metadata.to_json
           )
@@ -44,7 +44,7 @@ RSpec.describe SdrClient::Deposit::UpdateResource do
 
     context 'when there is an error' do
       before do
-        stub_request(:put, 'https://sdr-api-prod.stanford.edu/v1/resources/druid:gf123df7654?versionDescription=Updated%20metadata&user_versions=new')
+        stub_request(:put, 'https://sdr-api-prod.stanford.edu/v1/resources/druid:gf123df7654?versionDescription=Updated%20metadata&user_versions=new&accession=true')
           .with(
             body: metadata.to_json
           )

--- a/spec/sdr_client/redesigned_client/update_resource_spec.rb
+++ b/spec/sdr_client/redesigned_client/update_resource_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SdrClient::RedesignedClient::UpdateResource do
     let(:response_body) { '{"jobId":9}' }
     let(:response_status) { 202 }
     let(:optional_params) { {} }
-    let(:update_url) { 'http://example.com/v1/resources/druid:gf123df7654' }
+    let(:update_url) { 'http://example.com/v1/resources/druid:gf123df7654?accession=true' }
 
     before do
       stub_request(:put, update_url)
@@ -54,14 +54,21 @@ RSpec.describe SdrClient::RedesignedClient::UpdateResource do
 
     context 'with a version description' do
       let(:optional_params) { { version_description: 'Updated metadata' } }
-      let(:update_url) { 'http://example.com/v1/resources/druid:gf123df7654?versionDescription=Updated%20metadata' }
+      let(:update_url) { 'http://example.com/v1/resources/druid:gf123df7654?versionDescription=Updated%20metadata&accession=true' }
 
       it { is_expected.to eq 9 }
     end
 
     context 'with a user_versions' do
       let(:optional_params) { { user_versions: 'none' } }
-      let(:update_url) { 'http://example.com/v1/resources/druid:gf123df7654?user_versions=none' }
+      let(:update_url) { 'http://example.com/v1/resources/druid:gf123df7654?user_versions=none&accession=true' }
+
+      it { is_expected.to eq 9 }
+    end
+
+    context 'when not accessioning' do
+      let(:optional_params) { { accession: false } }
+      let(:update_url) { 'http://example.com/v1/resources/druid:gf123df7654' }
 
       it { is_expected.to eq 9 }
     end


### PR DESCRIPTION
## Why was this change made? 🤔
So that an object draft can be updated without closing.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡


