### PR TITLE
Avoid use of object_id instance variable.

### DIFF
--- a/lib/sdr_client/redesigned_client/find.rb
+++ b/lib/sdr_client/redesigned_client/find.rb
@@ -12,7 +12,7 @@ module SdrClient
 
       # @param [String] object_id an ID for an object
       def initialize(object_id:)
-        @object_id = object_id
+        @id = object_id
       end
 
       # @raise [Failed] if the find operation fails
@@ -24,7 +24,7 @@ module SdrClient
 
       private
 
-      attr_reader :object_id
+      attr_reader :id
 
       def logger
         SdrClient::RedesignedClient.config.logger
@@ -35,7 +35,7 @@ module SdrClient
       end
 
       def path
-        format('/v1/resources/%<object_id>s', object_id: object_id)
+        format('/v1/resources/%<id>s', id: id)
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
```
/opt/app/h2/happy-heron/shared/bundle/ruby/3.4.0/gems/sdr-client-2.18.0/lib/sdr_client/redesigned_client/find.rb:27: warning: redefining 'object_id' may cause serious problems
```


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡


