### PR TITLE
Update cocina-models to 0.103.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     sdr-client (2.21.1)
       activesupport
-      cocina-models (~> 0.103.0)
+      cocina-models (~> 0.103.1)
       config
       dry-monads
       faraday (>= 0.16)
@@ -36,7 +36,7 @@ GEM
     byebug (12.0.0)
     childprocess (5.1.0)
       logger (~> 1.5)
-    cocina-models (0.103.0)
+    cocina-models (0.103.1)
       activesupport
       deprecation
       dry-struct (~> 1.0)

--- a/sdr-client.gemspec
+++ b/sdr-client.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'cocina-models', '~> 0.103.0'
+  spec.add_dependency 'cocina-models', '~> 0.103.1'
   spec.add_dependency 'config'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday', '>= 0.16'


### PR DESCRIPTION
## Why was this change made? 🤔

Bump version of cocina-models to latest (0.103.1)

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that use sdr-api*** (e.g.create_object_h2_spec.rb) and/or test in [stage|qa] environment, in addition to specs. ⚡


